### PR TITLE
Added xOpera name and fixed XLAB name

### DIFF
--- a/interop/README.md
+++ b/interop/README.md
@@ -7,6 +7,6 @@ The following orchestrators are participants in this interoperability demonstrat
 * Ericsson
 * [Ubicity](https://ubicity.com)
 * [Unfurl](https://github.com/onecommons/unfurl)
-* [Xlab](https://github.com/xlab-si/xopera-opera)
+* [xOpera by XLAB](https://github.com/xlab-si/xopera-opera)
 ## Use Cases
 * Infrastructure-as-a-Service Clouds: deploy compute instances on Amazon Web Services, Microsoft Azure, and Google Cloud


### PR DESCRIPTION
Fixed typo - added orchestrator name and fixed the company name.

From the description it seems that there is a list of orchestrators and not company names, therefore I correct it. If we would like to add company names, I propose to have both (in the way I correct it). Feel free to not merge this if I missunderstand the purpose ;). 