### PR TITLE
Fix Endpoint type for Container.Application capability

### DIFF
--- a/profiles/org.oasis-open/simple/1.1/node.yaml
+++ b/profiles/org.oasis-open/simple/1.1/node.yaml
@@ -309,7 +309,7 @@ node_types:
       - storage:
           capability: tosca.capabilities.Storage
       - network:
-          capability: tosca.capabilities.EndPoint
+          capability: tosca.capabilities.Endpoint
 
   tosca.nodes.LoadBalancer:
     derived_from: tosca.nodes.Root

--- a/profiles/org.oasis-open/simple/1.2/node.yaml
+++ b/profiles/org.oasis-open/simple/1.2/node.yaml
@@ -321,7 +321,7 @@ node_types:
       - storage:
           capability: tosca.capabilities.Storage
       - network:
-          capability: tosca.capabilities.EndPoint
+          capability: tosca.capabilities.Endpoint
 
   tosca.nodes.LoadBalancer:
     derived_from: tosca.nodes.Root

--- a/profiles/org.oasis-open/simple/1.3/node.yaml
+++ b/profiles/org.oasis-open/simple/1.3/node.yaml
@@ -321,7 +321,7 @@ node_types:
       - storage:
           capability: tosca.capabilities.Storage
       - network:
-          capability: tosca.capabilities.EndPoint
+          capability: tosca.capabilities.Endpoint
 
   tosca.nodes.LoadBalancer:
     derived_from: tosca.nodes.Root

--- a/profiles/org.oasis-open/simple/2.0/node.yaml
+++ b/profiles/org.oasis-open/simple/2.0/node.yaml
@@ -325,7 +325,7 @@ node_types:
       - storage:
           capability: Storage
       - network:
-          capability: EndPoint
+          capability: Endpoint
 
   LoadBalancer:
     derived_from: Root


### PR DESCRIPTION
Since Simple Profile version 1.1 the `tosca.nodes.Container.Application` type has a misspelled capability type in the network requirement. There is no `EndPoint` type in the simple profile, so all the `node.yaml` files could be considered invalid since the [standard](https://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.3/os/TOSCA-Simple-Profile-YAML-v1.3-os.html#_Toc26969464) states:

> **Case sensitivity** - TOSCA Type URI, Shorthand and Type Qualified names SHALL be treated as case sensitive. 