### PR TITLE
Corrections to align files to TOSCA 1.0/1.1/1.2/1.3 specifications

### DIFF
--- a/profiles/org.oasis-open/simple/1.0/capability.yaml
+++ b/profiles/org.oasis-open/simple/1.0/capability.yaml
@@ -266,3 +266,9 @@ capability_types:
 
   tosca.capabilities.network.Bindable:
     derived_from: tosca.capabilities.Node
+
+  tosca.capabilities.network.Linkable:
+    derived_from: tosca.capabilities.Node
+    description: >
+      A node type that includes the Linkable capability indicates that it can
+      be pointed by tosca.relationships.network.LinksTo relationship type.

--- a/profiles/org.oasis-open/simple/1.0/capability.yaml
+++ b/profiles/org.oasis-open/simple/1.0/capability.yaml
@@ -10,6 +10,9 @@ description: >-
   capability types as defined in the TOSCA Simple Profile for YAML
   v1.0 specification.
 
+imports:
+  - data.yaml
+
 capability_types:
 
   tosca.capabilities.Root:

--- a/profiles/org.oasis-open/simple/1.0/data.yaml
+++ b/profiles/org.oasis-open/simple/1.0/data.yaml
@@ -55,7 +55,7 @@ data_types:
 
   tosca.datatypes.network.NetworkInfo:
     derived_from: tosca.datatypes.Root
-    properties:  
+    properties:
       network_name:
         type: string
       network_id:
@@ -67,7 +67,7 @@ data_types:
 
   tosca.datatypes.network.PortInfo:
     derived_from: tosca.datatypes.Root
-    properties:  
+    properties:
       port_name:
         type: string
       port_id:
@@ -88,22 +88,26 @@ data_types:
 
   tosca.datatypes.network.PortSpec:
     derived_from: tosca.datatypes.Root
-    properties:  
+    properties:
       protocol:
         type: string
         required: true
         default: tcp
         constraints:
           - valid_values: [ udp, tcp, igmp ]
-      target: 
+      target:
         type: tosca.datatypes.network.PortDef
+        required: false
       target_range:
         type: range
+        required: false
         constraints:
           - in_range: [ 1, 65535 ]
       source:
         type: tosca.datatypes.network.PortDef
+        required: false
       source_range:
         type: range
+        required: false
         constraints:
           - in_range: [ 1, 65535 ]

--- a/profiles/org.oasis-open/simple/1.0/group.yaml
+++ b/profiles/org.oasis-open/simple/1.0/group.yaml
@@ -5,6 +5,9 @@ metadata:
   template_author: TOSCA TC
   template_version: 1.0.0
 
+imports:
+  - interface.yaml
+
 description: >-
   This TOSCA definitions document contains the TOSCA Simple Profile
   group types as defined in the TOSCA Simple Profile for YAML v1.0

--- a/profiles/org.oasis-open/simple/1.0/node.yaml
+++ b/profiles/org.oasis-open/simple/1.0/node.yaml
@@ -10,6 +10,12 @@ description: >-
   node types as defined in the TOSCA Simple Profile for YAML v1.0
   specification.
 
+imports:
+  - data.yaml
+  - capability.yaml
+  - interface.yaml
+  - relationship.yaml
+
 node_types:
 
   tosca.nodes.Root:
@@ -310,7 +316,7 @@ node_types:
     capabilities:
       client:
         type: tosca.capabilities.Endpoint.Public
-        occurrences: [0, UNBOUNDED] 
+        occurrences: [0, UNBOUNDED]
         description: >-
           the Floating (IP) client’s on the public network can connect
           to
@@ -318,6 +324,6 @@ node_types:
       - application:
           capability: tosca.capabilities.Endpoint
           relationship: tosca.relationships.RoutesTo
-          occurrences: [0, UNBOUNDED] 
+          occurrences: [0, UNBOUNDED]
           description: >-
             Connection to one or more load balanced applications

--- a/profiles/org.oasis-open/simple/1.0/node.yaml
+++ b/profiles/org.oasis-open/simple/1.0/node.yaml
@@ -327,3 +327,174 @@ node_types:
           occurrences: [0, UNBOUNDED]
           description: >-
             Connection to one or more load balanced applications
+
+  tosca.nodes.network.Network:
+    derived_from: tosca.nodes.Root
+    description: >
+      The TOSCA Network node represents a simple, logical network service.
+    properties:
+      ip_version:
+        description: >
+          The IP version of the requested network.
+        type: integer
+        required: false
+        default: 4
+        constraints:
+          - valid_values: [ 4, 6 ]
+      cidr:
+        description: >
+          The cidr block of the requested network.
+        type: string
+        required: false
+      start_ip:
+        description: >
+          The IP address to be used as the 1st one in a pool of addresses
+          derived from the cidr block full IP range.
+        type: string
+        required: false
+      end_ip:
+        description: >
+          The IP address to be used as the last one in a pool of addresses
+          derived from the cidr block full IP range.
+        type: string
+        required: false
+      gateway_ip:
+        description: >
+          The gateway IP address.
+        type: string
+        required: false
+      network_name:
+        description: >
+          An Identifier that represents an existing Network instance in the
+          underlying cloud infrastructure – OR – be used as the name of the
+          new created network.
+          * If network_name is provided along with network_id they will be
+          used to uniquely identify an existing network and not creating a
+          new one, means all other possible properties are not allowed.
+          * network_name should be more convenient for using. But in case
+          that network name uniqueness is not guaranteed then one should
+          provide a network_id as well.
+        type: string
+        required: false
+      network_id:
+        description: >
+          An Identifier that represents an existing Network instance in
+          the underlying cloud infrastructure.
+          This property is mutually exclusive with all other properties
+          except network_name.
+          * Appearance of network_id in network template instructs the
+          Tosca container to use an existing network instead of creating
+          a new one.
+          * network_name should be more convenient for using. But in case
+          that network name uniqueness is not guaranteed then one should
+          add a network_id as well.
+          * network_name and network_id can be still used together to achieve
+          both uniqueness and convenient.
+        type: string
+        required: false
+      segmentation_id:
+        description: >
+          A segmentation identifier in the underlying cloud infrastructure
+          (e.g., VLAN id, GRE tunnel id). If the segmentation_id is specified,
+          the network_type or physical_network properties should be provided
+          as well.
+        type: string
+        required: false
+      network_type:
+        description: >
+          Optionally, specifies the nature of the physical network in
+          the underlying cloud infrastructure. Examples are flat, vlan,
+          gre or vxlan. For flat and vlan types, physical_network should
+          be provided too.
+        type: string
+        required: false
+      physical_network:
+        description: >
+          Optionally, identifies the physical network on top of which the
+          network is implemented, e.g. physnet1. This property is required
+          if network_type is flat or vlan.
+        type: string
+        required: false
+      dhcp_enabled:
+        description: >
+          Indicates the TOSCA container to create a virtual network instance
+          with or without a DHCP service.
+        type: boolean
+        required: false
+        default: true
+    attributes:
+      segmentation_id:
+        description: >
+          The actual segmentation_id that is been assigned to the network
+          by the underlying cloud infrastructure.
+        type: string
+    capabilities:
+      link:
+        type: tosca.capabilities.network.Linkable
+
+  tosca.nodes.network.Port:
+    derived_from: tosca.nodes.Root
+    description: >
+      The TOSCA Port node represents a logical entity that associates
+      between Compute and Network normative types.
+      The Port node type effectively represents a single virtual NIC on
+      the Compute node instance.
+    properties:
+      ip_address:
+        description: >
+          Allow the user to set a fixed IP address.
+          Note that this address is a request to the provider which
+          they will attempt to fulfill but may not be able to dependent
+          on the network the port is associated with.
+        type: string
+        required: false
+      order:
+        description: >
+          The order of the NIC on the compute instance (e.g. eth2).
+          Note: when binding more than one port to a single compute
+          (aka multi vNICs) and ordering is desired, it is *mandatory*
+          that all ports will be set with an order value and. The order
+          values must represent a positive, arithmetic progression that
+          starts with 0 (e.g. 0, 1, 2, ..., n).
+        type: integer
+        required: true
+        default: 0
+        constraints:
+          - greater_or_equal: 0
+      is_default:
+        description: >
+          Set is_default=true to apply a default gateway route on the
+          running compute instance to the associated network gateway.
+          Only one port that is associated to single compute node can
+          set as default=true.
+        type: boolean
+        required: false
+        default: false
+      ip_range_start:
+        description: >
+          Defines the starting IP of a range to be allocated for the
+          compute instances that are associated by this Port.
+          Without setting this property the IP allocation is done from
+          the entire CIDR block of the network.
+        type: string
+        required: false
+      ip_range_end:
+        description: >
+          Defines the ending IP of a range to be allocated for the
+          compute instances that are associated by this Port.
+          Without setting this property the IP allocation is done from
+          the entire CIDR block of the network.
+        type: string
+        required: false
+    attributes:
+      ip_address:
+        description: >
+          The IP address would be assigned to the associated compute instance.
+        type: string
+    requirements:
+     - link:
+        capability: tosca.capabilities.network.Linkable
+        relationship: tosca.relationships.network.LinksTo
+     - binding:
+        capability: tosca.capabilities.network.Bindable
+        relationship: tosca.relationships.network.BindsTo

--- a/profiles/org.oasis-open/simple/1.0/relationship.yaml
+++ b/profiles/org.oasis-open/simple/1.0/relationship.yaml
@@ -10,6 +10,11 @@ description: >-
   relationship types as defined in the TOSCA Simple Profile for YAML
   v1.0 specification.
 
+imports:
+  - data.yaml
+  - capability.yaml
+  - interface.yaml
+
 relationship_types:
 
   tosca.relationships.Root:

--- a/profiles/org.oasis-open/simple/1.0/relationship.yaml
+++ b/profiles/org.oasis-open/simple/1.0/relationship.yaml
@@ -91,3 +91,17 @@ relationship_types:
       This type represents an intentional network routing between two
       Endpoints in different networks.
     valid_target_types: [ tosca.capabilities.Endpoint ]
+
+  tosca.relationships.network.LinksTo:
+    derived_from: tosca.relationships.DependsOn
+    description: >
+      This relationship type represents an association relationship between
+      Port and Network node types.
+    valid_target_types: [ tosca.capabilities.network.Linkable ]
+
+  tosca.relationships.network.BindsTo:
+    derived_from: tosca.relationships.DependsOn
+    description: >
+      This type represents a network association relationship between Port
+      and Compute node types.
+    valid_target_types: [ tosca.capabilities.network.Bindable ]

--- a/profiles/org.oasis-open/simple/1.1/capability.yaml
+++ b/profiles/org.oasis-open/simple/1.1/capability.yaml
@@ -10,6 +10,9 @@ description: >-
   capability types as defined in the TOSCA Simple Profile for YAML
   v1.1 specification.
 
+imports:
+  - data.yaml
+
 capability_types:
 
   tosca.capabilities.Root:
@@ -30,7 +33,7 @@ capability_types:
       definition, indicates that the node can provide hosting on a
       named compute resource.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The otional name (or identifier) of a specific compute
@@ -77,7 +80,7 @@ capability_types:
       definition, indicates that the node can provide addressiblity
       for the resource on a named network with the specified ports.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The otional name (or identifier) of a specific network
@@ -91,7 +94,7 @@ capability_types:
       definition, indicates that the node can provide a named storage
       location with specified size range.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The otional name (or identifier) of a specific storage

--- a/profiles/org.oasis-open/simple/1.1/capability.yaml
+++ b/profiles/org.oasis-open/simple/1.1/capability.yaml
@@ -310,3 +310,9 @@ capability_types:
       A node type that includes the Bindable capability indicates that
       it can be bound to a logical network association via a network
       port.
+
+  tosca.capabilities.network.Linkable:
+    derived_from: tosca.capabilities.Node
+    description: >
+      A node type that includes the Linkable capability indicates that it can
+      be pointed to by a tosca.relationships.network.LinksTo relationship type.

--- a/profiles/org.oasis-open/simple/1.1/data.yaml
+++ b/profiles/org.oasis-open/simple/1.1/data.yaml
@@ -53,18 +53,18 @@ data_types:
           credentials.
         required: false
 
-  tosca.datatypes.TimeInterval: 
+  tosca.datatypes.TimeInterval:
     derived_from: tosca.datatypes.Root
     description: >-
       The TimeInterval type describes a period of time using the YAML
       ISO 8601 format to declare the start and end times.
     properties:
-      start_time: 
+      start_time:
         type: timestamp
         description: >-
           The inclusive start time for the time interval.
         required: true
-      end_time: 
+      end_time:
         type: timestamp
         description: >-
           The inclusive end time for the time interval.
@@ -74,7 +74,7 @@ data_types:
     derived_from: tosca.datatypes.Root
     description: >-
       The Network type describes logical network information.
-    properties:  
+    properties:
       network_name:
         type: string
         description: >-
@@ -97,7 +97,7 @@ data_types:
     derived_from: tosca.datatypes.Root
     description: >-
       The PortInfo type describes network port information.
-    properties:  
+    properties:
       port_name:
         type: string
         description: >-
@@ -135,7 +135,7 @@ data_types:
     description: >-
       The PortSpec type describes port specifications for a network
       connection.
-    properties:  
+    properties:
       protocol:
         type: string
         description: >-
@@ -147,20 +147,24 @@ data_types:
       source:
         type: tosca.datatypes.network.PortDef
         description: >-
-          The optional source port.          
+          The optional source port.
+        required: false
       source_range:
         type: range
         description: >-
-          The optional range for the source port. 
+          The optional range for the source port.
+        required: false
         constraints:
           - in_range: [ 1, 65535 ]
-      target: 
+      target:
         type: tosca.datatypes.network.PortDef
         description: >-
-          The optional target port.  
+          The optional target port.
+        required: false
       target_range:
         type: range
         description: >-
           The optional range for the target port.
+        required: false
         constraints:
           - in_range: [ 1, 65535 ]

--- a/profiles/org.oasis-open/simple/1.1/group.yaml
+++ b/profiles/org.oasis-open/simple/1.1/group.yaml
@@ -10,6 +10,9 @@ description: >-
   group types as defined in the TOSCA Simple Profile for YAML v1.1
   specification.
 
+imports:
+  - interface.yaml
+
 group_types:
   tosca.groups.Root:
     description: >-

--- a/profiles/org.oasis-open/simple/1.1/node.yaml
+++ b/profiles/org.oasis-open/simple/1.1/node.yaml
@@ -343,3 +343,174 @@ node_types:
           occurrences: [0, UNBOUNDED]
           description: >-
             Connection to one or more load balanced applications
+
+  tosca.nodes.network.Network:
+    derived_from: tosca.nodes.Root
+    description: >
+      The TOSCA Network node represents a simple, logical network service.
+    properties:
+      ip_version:
+        description: >
+          The IP version of the requested network.
+        type: integer
+        required: false
+        default: 4
+        constraints:
+          - valid_values: [ 4, 6 ]
+      cidr:
+        description: >
+          The cidr block of the requested network.
+        type: string
+        required: false
+      start_ip:
+        description: >
+          The IP address to be used as the 1st one in a pool of addresses
+          derived from the cidr block full IP range.
+        type: string
+        required: false
+      end_ip:
+        description: >
+          The IP address to be used as the last one in a pool of addresses
+          derived from the cidr block full IP range.
+        type: string
+        required: false
+      gateway_ip:
+        description: >
+          The gateway IP address.
+        type: string
+        required: false
+      network_name:
+        description: >
+          An Identifier that represents an existing Network instance in the
+          underlying cloud infrastructure – OR – be used as the name of the
+          new created network.
+          . If network_name is provided along with network_id they will be
+          used to uniquely identify an existing network and not creating a
+          new one, means all other possible properties are not allowed.
+          . network_name should be more convenient for using. But in case
+          that network name uniqueness is not guaranteed then one should
+          provide a network_id as well.
+        type: string
+        required: false
+      network_id:
+        description: >
+          An Identifier that represents an existing Network instance in
+          the underlying cloud infrastructure.
+          This property is mutually exclusive with all other properties
+          except network_name.
+          . Appearance of network_id in network template instructs the
+          Tosca container to use an existing network instead of creating
+          a new one.
+          . network_name should be more convenient for using. But in case
+          that network name uniqueness is not guaranteed then one should
+          add a network_id as well.
+          . network_name and network_id can be still used together to achieve
+          both uniqueness and convenient.
+        type: string
+        required: false
+      segmentation_id:
+        description: >
+          A segmentation identifier in the underlying cloud infrastructure
+          (e.g., VLAN id, GRE tunnel id). If the segmentation_id is specified,
+          the network_type or physical_network properties should be provided
+          as well.
+        type: string
+        required: false
+      network_type:
+        description: >
+          Optionally, specifies the nature of the physical network in
+          the underlying cloud infrastructure. Examples are flat, vlan,
+          gre or vxlan. For flat and vlan types, physical_network should
+          be provided too.
+        type: string
+        required: false
+      physical_network:
+        description: >
+          Optionally, identifies the physical network on top of which the
+          network is implemented, e.g. physnet1. This property is required
+          if network_type is flat or vlan.
+        type: string
+        required: false
+      dhcp_enabled:
+        description: >
+          Indicates the TOSCA container to create a virtual network instance
+          with or without a DHCP service.
+        type: boolean
+        required: false
+        default: true
+    attributes:
+      segmentation_id:
+        description: >
+          The actual segmentation_id that is been assigned to the network
+          by the underlying cloud infrastructure.
+        type: string
+    capabilities:
+      link:
+        type: tosca.capabilities.network.Linkable
+
+  tosca.nodes.network.Port:
+    derived_from: tosca.nodes.Root
+    description: >
+      The TOSCA Port node represents a logical entity that associates
+      between Compute and Network normative types.
+      The Port node type effectively represents a single virtual NIC on
+      the Compute node instance.
+    properties:
+      ip_address:
+        description: >
+          Allow the user to set a fixed IP address.
+          Note that this address is a request to the provider which
+          they will attempt to fulfill but may not be able to dependent
+          on the network the port is associated with.
+        type: string
+        required: false
+      order:
+        description: >
+          The order of the NIC on the compute instance (e.g. eth2).
+          Note: when binding more than one port to a single compute
+          (aka multi vNICs) and ordering is desired, it is *mandatory*
+          that all ports will be set with an order value and. The order
+          values must represent a positive, arithmetic progression that
+          starts with 0 (e.g. 0, 1, 2, ..., n).
+        type: integer
+        required: true
+        default: 0
+        constraints:
+          - greater_or_equal: 0
+      is_default:
+        description: >
+          Set is_default=true to apply a default gateway route on the
+          running compute instance to the associated network gateway.
+          Only one port that is associated to single compute node can
+          set as default=true.
+        type: boolean
+        required: false
+        default: false
+      ip_range_start:
+        description: >
+          Defines the starting IP of a range to be allocated for the
+          compute instances that are associated by this Port.
+          Without setting this property the IP allocation is done from
+          the entire CIDR block of the network.
+        type: string
+        required: false
+      ip_range_end:
+        description: >
+          Defines the ending IP of a range to be allocated for the
+          compute instances that are associated by this Port.
+          Without setting this property the IP allocation is done from
+          the entire CIDR block of the network.
+        type: string
+        required: false
+    attributes:
+      ip_address:
+        description: >
+          The IP address would be assigned to the associated compute instance.
+        type: string
+    requirements:
+     - link:
+        capability: tosca.capabilities.network.Linkable
+        relationship: tosca.relationships.network.LinksTo
+     - binding:
+        capability: tosca.capabilities.network.Bindable
+        relationship: tosca.relationships.network.BindsTo

--- a/profiles/org.oasis-open/simple/1.1/node.yaml
+++ b/profiles/org.oasis-open/simple/1.1/node.yaml
@@ -10,6 +10,12 @@ description: >-
   node types as defined in the TOSCA Simple Profile for YAML v1.1
   specification.
 
+imports:
+  - data.yaml
+  - capability.yaml
+  - interface.yaml
+  - relationship.yaml
+
 node_types:
 
   tosca.nodes.Root:
@@ -326,7 +332,7 @@ node_types:
     capabilities:
       client:
         type: tosca.capabilities.Endpoint.Public
-        occurrences: [0, UNBOUNDED] 
+        occurrences: [0, UNBOUNDED]
         description: >-
           the Floating (IP) client’s on the public network can connect
           to
@@ -334,6 +340,6 @@ node_types:
       - application:
           capability: tosca.capabilities.Endpoint
           relationship: tosca.relationships.RoutesTo
-          occurrences: [0, UNBOUNDED] 
+          occurrences: [0, UNBOUNDED]
           description: >-
             Connection to one or more load balanced applications

--- a/profiles/org.oasis-open/simple/1.1/relationship.yaml
+++ b/profiles/org.oasis-open/simple/1.1/relationship.yaml
@@ -91,3 +91,17 @@ relationship_types:
       This type represents an intentional network routing between two
       Endpoints in different networks.
     valid_target_types: [ tosca.capabilities.Endpoint ]
+
+  tosca.relationships.network.LinksTo:
+    derived_from: tosca.relationships.DependsOn
+    description: >
+      This relationship type represents an association relationship between
+      Port and Network node types.
+    valid_target_types: [ tosca.capabilities.network.Linkable ]
+
+  tosca.relationships.network.BindsTo:
+    derived_from: tosca.relationships.DependsOn
+    description: >
+      This type represents a network association relationship between Port
+      and Compute node types.
+    valid_target_types: [ tosca.capabilities.network.Bindable ]

--- a/profiles/org.oasis-open/simple/1.1/relationship.yaml
+++ b/profiles/org.oasis-open/simple/1.1/relationship.yaml
@@ -10,6 +10,11 @@ description: >-
   relationship types as defined in the TOSCA Simple Profile for YAML
   v1.1 specification.
 
+imports:
+  - data.yaml
+  - capability.yaml
+  - interface.yaml
+
 relationship_types:
 
   tosca.relationships.Root:

--- a/profiles/org.oasis-open/simple/1.2/capability.yaml
+++ b/profiles/org.oasis-open/simple/1.2/capability.yaml
@@ -310,3 +310,9 @@ capability_types:
       A node type that includes the Bindable capability indicates that
       it can be bound to a logical network association via a network
       port.
+
+  tosca.capabilities.network.Linkable:
+    derived_from: tosca.capabilities.Node
+    description: >
+      A node type that includes the Linkable capability indicates that it can
+      be pointed to by a tosca.relationships.network.LinksTo relationship type.

--- a/profiles/org.oasis-open/simple/1.2/capability.yaml
+++ b/profiles/org.oasis-open/simple/1.2/capability.yaml
@@ -10,6 +10,9 @@ description: >-
   capability types as defined in the TOSCA Simple Profile for YAML
   v1.3 specification.
 
+imports:
+  - data.yaml
+
 capability_types:
 
   tosca.capabilities.Root:
@@ -38,7 +41,7 @@ capability_types:
       definition, indicates that the node can provide hosting on a
       named compute resource.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The otional name (or identifier) of a specific compute
@@ -85,7 +88,7 @@ capability_types:
       definition, indicates that the node can provide addressiblity
       for the resource on a named network with the specified ports.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The otional name (or identifier) of a specific network
@@ -99,7 +102,7 @@ capability_types:
       definition, indicates that the node can provide a named storage
       location with specified size range.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The otional name (or identifier) of a specific storage

--- a/profiles/org.oasis-open/simple/1.2/data.yaml
+++ b/profiles/org.oasis-open/simple/1.2/data.yaml
@@ -65,18 +65,18 @@ data_types:
           credentials.
         required: false
 
-  tosca.datatypes.TimeInterval: 
+  tosca.datatypes.TimeInterval:
     derived_from: tosca.datatypes.Root
     description: >-
       The TimeInterval type describes a period of time using the YAML
       ISO 8601 format to declare the start and end times.
     properties:
-      start_time: 
+      start_time:
         type: timestamp
         description: >-
           The inclusive start time for the time interval.
         required: true
-      end_time: 
+      end_time:
         type: timestamp
         description: >-
           The inclusive end time for the time interval.
@@ -86,7 +86,7 @@ data_types:
     derived_from: tosca.datatypes.Root
     description: >-
       The Network type describes logical network information.
-    properties:  
+    properties:
       network_name:
         type: string
         description: >-
@@ -109,7 +109,7 @@ data_types:
     derived_from: tosca.datatypes.Root
     description: >-
       The PortInfo type describes network port information.
-    properties:  
+    properties:
       port_name:
         type: string
         description: >-
@@ -147,7 +147,7 @@ data_types:
     description: >-
       The PortSpec type describes port specifications for a network
       connection.
-    properties:  
+    properties:
       protocol:
         type: string
         description: >-
@@ -159,20 +159,24 @@ data_types:
       source:
         type: tosca.datatypes.network.PortDef
         description: >-
-          The optional source port.          
+          The optional source port.
+        required: false
       source_range:
         type: range
         description: >-
-          The optional range for the source port. 
+          The optional range for the source port.
+        required: false
         constraints:
           - in_range: [ 1, 65535 ]
-      target: 
+      target:
         type: tosca.datatypes.network.PortDef
         description: >-
-          The optional target port.  
+          The optional target port.
+        required: false
       target_range:
         type: range
         description: >-
           The optional range for the target port.
+        required: false
         constraints:
           - in_range: [ 1, 65535 ]

--- a/profiles/org.oasis-open/simple/1.2/group.yaml
+++ b/profiles/org.oasis-open/simple/1.2/group.yaml
@@ -5,6 +5,9 @@ metadata:
   template_author: TOSCA TC
   template_version: 1.2.0
 
+imports:
+  - interface.yaml
+
 description: >-
   This TOSCA definitions document contains the TOSCA Simple Profile
   group types as defined in the TOSCA Simple Profile for YAML v1.2

--- a/profiles/org.oasis-open/simple/1.2/node.yaml
+++ b/profiles/org.oasis-open/simple/1.2/node.yaml
@@ -138,7 +138,7 @@ node_types:
         required: false
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.Compute
           relationship: tosca.relationships.HostedOn
 
@@ -153,7 +153,7 @@ node_types:
       data_endpoint: tosca.capabilities.Endpoint
       admin_endpoint: tosca.capabilities.Endpoint.Admin
       host:
-        type: tosca.capabilities.Container
+        type: tosca.capabilities.Compute
         valid_source_types: [ tosca.nodes.WebApplication ]
 
   tosca.nodes.WebApplication:
@@ -176,7 +176,7 @@ node_types:
         type: tosca.capabilities.Endpoint
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.WebServer
           relationship: tosca.relationships.HostedOn
 
@@ -196,7 +196,7 @@ node_types:
         description: the port the DBMS service will listen to for data and requests
     capabilities:
       host:
-        type: tosca.capabilities.Container
+        type: tosca.capabilities.Compute
         valid_source_types: [ tosca.nodes.Database ]
 
   tosca.nodes.Database:
@@ -228,7 +228,7 @@ node_types:
         required: false
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.DBMS
           relationship: tosca.relationships.HostedOn
     capabilities:

--- a/profiles/org.oasis-open/simple/1.2/node.yaml
+++ b/profiles/org.oasis-open/simple/1.2/node.yaml
@@ -251,6 +251,7 @@ node_types:
         description: >-
           The requested initial storage size (default unit is in
           Gigabytes).
+        required: false
         default: 0 MB
         constraints:
           - greater_or_equal: 0 MB
@@ -274,7 +275,7 @@ node_types:
       storage_endpoint:
         type: tosca.capabilities.Endpoint
 
-  tosca.nodes.BlockStorage:
+  tosca.nodes.Storage.BlockStorage:
     derived_from: tosca.nodes.Abstract.Storage
     description: >
       The TOSCA BlockStorage node currently represents a server-local
@@ -355,3 +356,174 @@ node_types:
           occurrences: [0, UNBOUNDED]
           description: >-
             Connection to one or more load balanced applications
+
+  tosca.nodes.network.Network:
+    derived_from: tosca.nodes.Root
+    description: >
+      The TOSCA Network node represents a simple, logical network service.
+    properties:
+      ip_version:
+        description: >
+          The IP version of the requested network.
+        type: integer
+        required: false
+        default: 4
+        constraints:
+          - valid_values: [ 4, 6 ]
+      cidr:
+        description: >
+          The cidr block of the requested network.
+        type: string
+        required: false
+      start_ip:
+        description: >
+          The IP address to be used as the 1st one in a pool of addresses
+          derived from the cidr block full IP range.
+        type: string
+        required: false
+      end_ip:
+        description: >
+          The IP address to be used as the last one in a pool of addresses
+          derived from the cidr block full IP range.
+        type: string
+        required: false
+      gateway_ip:
+        description: >
+          The gateway IP address.
+        type: string
+        required: false
+      network_name:
+        description: >
+          An Identifier that represents an existing Network instance in the
+          underlying cloud infrastructure – OR – be used as the name of the
+          new created network.
+          . If network_name is provided along with network_id they will be
+          used to uniquely identify an existing network and not creating a
+          new one, means all other possible properties are not allowed.
+          . network_name should be more convenient for using. But in case
+          that network name uniqueness is not guaranteed then one should
+          provide a network_id as well.
+        type: string
+        required: false
+      network_id:
+        description: >
+          An Identifier that represents an existing Network instance in
+          the underlying cloud infrastructure.
+          This property is mutually exclusive with all other properties
+          except network_name.
+          . Appearance of network_id in network template instructs the
+          Tosca container to use an existing network instead of creating
+          a new one.
+          . network_name should be more convenient for using. But in case
+          that network name uniqueness is not guaranteed then one should
+          add a network_id as well.
+          . network_name and network_id can be still used together to achieve
+          both uniqueness and convenient.
+        type: string
+        required: false
+      segmentation_id:
+        description: >
+          A segmentation identifier in the underlying cloud infrastructure
+          (e.g., VLAN id, GRE tunnel id). If the segmentation_id is specified,
+          the network_type or physical_network properties should be provided
+          as well.
+        type: string
+        required: false
+      network_type:
+        description: >
+          Optionally, specifies the nature of the physical network in
+          the underlying cloud infrastructure. Examples are flat, vlan,
+          gre or vxlan. For flat and vlan types, physical_network should
+          be provided too.
+        type: string
+        required: false
+      physical_network:
+        description: >
+          Optionally, identifies the physical network on top of which the
+          network is implemented, e.g. physnet1. This property is required
+          if network_type is flat or vlan.
+        type: string
+        required: false
+      dhcp_enabled:
+        description: >
+          Indicates the TOSCA container to create a virtual network instance
+          with or without a DHCP service.
+        type: boolean
+        required: false
+        default: true
+    attributes:
+      segmentation_id:
+        description: >
+          The actual segmentation_id that is been assigned to the network
+          by the underlying cloud infrastructure.
+        type: string
+    capabilities:
+      link:
+        type: tosca.capabilities.network.Linkable
+
+  tosca.nodes.network.Port:
+    derived_from: tosca.nodes.Root
+    description: >
+      The TOSCA Port node represents a logical entity that associates
+      between Compute and Network normative types.
+      The Port node type effectively represents a single virtual NIC on
+      the Compute node instance.
+    properties:
+      ip_address:
+        description: >
+          Allow the user to set a fixed IP address.
+          Note that this address is a request to the provider which
+          they will attempt to fulfill but may not be able to dependent
+          on the network the port is associated with.
+        type: string
+        required: false
+      order:
+        description: >
+          The order of the NIC on the compute instance (e.g. eth2).
+          Note: when binding more than one port to a single compute
+          (aka multi vNICs) and ordering is desired, it is *mandatory*
+          that all ports will be set with an order value and. The order
+          values must represent a positive, arithmetic progression that
+          starts with 0 (e.g. 0, 1, 2, ..., n).
+        type: integer
+        required: true
+        default: 0
+        constraints:
+          - greater_or_equal: 0
+      is_default:
+        description: >
+          Set is_default=true to apply a default gateway route on the
+          running compute instance to the associated network gateway.
+          Only one port that is associated to single compute node can
+          set as default=true.
+        type: boolean
+        required: false
+        default: false
+      ip_range_start:
+        description: >
+          Defines the starting IP of a range to be allocated for the
+          compute instances that are associated by this Port.
+          Without setting this property the IP allocation is done from
+          the entire CIDR block of the network.
+        type: string
+        required: false
+      ip_range_end:
+        description: >
+          Defines the ending IP of a range to be allocated for the
+          compute instances that are associated by this Port.
+          Without setting this property the IP allocation is done from
+          the entire CIDR block of the network.
+        type: string
+        required: false
+    attributes:
+      ip_address:
+        description: >
+          The IP address would be assigned to the associated compute instance.
+        type: string
+    requirements:
+     - link:
+        capability: tosca.capabilities.network.Linkable
+        relationship: tosca.relationships.network.LinksTo
+     - binding:
+        capability: tosca.capabilities.network.Bindable
+        relationship: tosca.relationships.network.BindsTo

--- a/profiles/org.oasis-open/simple/1.2/node.yaml
+++ b/profiles/org.oasis-open/simple/1.2/node.yaml
@@ -10,6 +10,12 @@ description: >-
   node types as defined in the TOSCA Simple Profile for YAML v1.2
   specification.
 
+imports:
+  - data.yaml
+  - capability.yaml
+  - interface.yaml
+  - relationship.yaml
+
 node_types:
 
   tosca.nodes.Root:
@@ -60,7 +66,7 @@ node_types:
       resource without any requirements on storage or network
       resources.
     capabilities:
-      host: 
+      host:
         type: tosca.capabilities.Compute
         valid_source_types: []
 
@@ -236,11 +242,11 @@ node_types:
       resource without any requirements on compute or network
       resources.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The logical name (or ID) of the storage resource.
-      size: 
+      size:
         type: scalar-unit.size
         description: >-
           The requested initial storage size (default unit is in
@@ -304,7 +310,7 @@ node_types:
     capabilities:
       host:
         type: tosca.capabilities.Compute
-        valid_source_types: [tosca.nodes.Container.Application]        
+        valid_source_types: [tosca.nodes.Container.Application]
       scalable:
         type: tosca.capabilities.Scalable
 
@@ -338,7 +344,7 @@ node_types:
     capabilities:
       client:
         type: tosca.capabilities.Endpoint.Public
-        occurrences: [0, UNBOUNDED] 
+        occurrences: [0, UNBOUNDED]
         description: >-
           the Floating (IP) client’s on the public network can connect
           to
@@ -346,6 +352,6 @@ node_types:
       - application:
           capability: tosca.capabilities.Endpoint
           relationship: tosca.relationships.RoutesTo
-          occurrences: [0, UNBOUNDED] 
+          occurrences: [0, UNBOUNDED]
           description: >-
             Connection to one or more load balanced applications

--- a/profiles/org.oasis-open/simple/1.2/relationship.yaml
+++ b/profiles/org.oasis-open/simple/1.2/relationship.yaml
@@ -91,3 +91,17 @@ relationship_types:
       This type represents an intentional network routing between two
       Endpoints in different networks.
     valid_target_types: [ tosca.capabilities.Endpoint ]
+
+  tosca.relationships.network.LinksTo:
+    derived_from: tosca.relationships.DependsOn
+    description: >
+      This relationship type represents an association relationship between
+      Port and Network node types.
+    valid_target_types: [ tosca.capabilities.network.Linkable ]
+
+  tosca.relationships.network.BindsTo:
+    derived_from: tosca.relationships.DependsOn
+    description: >
+      This type represents a network association relationship between Port
+      and Compute node types.
+    valid_target_types: [ tosca.capabilities.network.Bindable ]

--- a/profiles/org.oasis-open/simple/1.2/relationship.yaml
+++ b/profiles/org.oasis-open/simple/1.2/relationship.yaml
@@ -10,6 +10,11 @@ description: >-
   relationship types as defined in the TOSCA Simple Profile for YAML
   v1.2 specification.
 
+imports:
+  - data.yaml
+  - capability.yaml
+  - interface.yaml
+
 relationship_types:
 
   tosca.relationships.Root:

--- a/profiles/org.oasis-open/simple/1.3/capability.yaml
+++ b/profiles/org.oasis-open/simple/1.3/capability.yaml
@@ -310,3 +310,9 @@ capability_types:
       A node type that includes the Bindable capability indicates that
       it can be bound to a logical network association via a network
       port.
+
+  tosca.capabilities.network.Linkable:
+    description: >-
+      A node type that includes the Linkable capability indicates that
+      it can be pointed to by a tosca.relationships.network.LinksTo relationship type.
+    derived_from: tosca.capabilities.Node

--- a/profiles/org.oasis-open/simple/1.3/capability.yaml
+++ b/profiles/org.oasis-open/simple/1.3/capability.yaml
@@ -10,6 +10,9 @@ description: >-
   capability types as defined in the TOSCA Simple Profile for YAML
   v1.3 specification.
 
+imports:
+  - data.yaml
+
 capability_types:
 
   tosca.capabilities.Root:
@@ -38,7 +41,7 @@ capability_types:
       definition, indicates that the node can provide hosting on a
       named compute resource.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The otional name (or identifier) of a specific compute
@@ -85,7 +88,7 @@ capability_types:
       definition, indicates that the node can provide addressiblity
       for the resource on a named network with the specified ports.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The otional name (or identifier) of a specific network
@@ -99,7 +102,7 @@ capability_types:
       definition, indicates that the node can provide a named storage
       location with specified size range.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The otional name (or identifier) of a specific storage

--- a/profiles/org.oasis-open/simple/1.3/data.yaml
+++ b/profiles/org.oasis-open/simple/1.3/data.yaml
@@ -65,18 +65,18 @@ data_types:
           credentials.
         required: false
 
-  tosca.datatypes.TimeInterval: 
+  tosca.datatypes.TimeInterval:
     derived_from: tosca.datatypes.Root
     description: >-
       The TimeInterval type describes a period of time using the YAML
       ISO 8601 format to declare the start and end times.
     properties:
-      start_time: 
+      start_time:
         type: timestamp
         description: >-
           The inclusive start time for the time interval.
         required: true
-      end_time: 
+      end_time:
         type: timestamp
         description: >-
           The inclusive end time for the time interval.
@@ -86,7 +86,7 @@ data_types:
     derived_from: tosca.datatypes.Root
     description: >-
       The Network type describes logical network information.
-    properties:  
+    properties:
       network_name:
         type: string
         description: >-
@@ -109,7 +109,7 @@ data_types:
     derived_from: tosca.datatypes.Root
     description: >-
       The PortInfo type describes network port information.
-    properties:  
+    properties:
       port_name:
         type: string
         description: >-
@@ -147,7 +147,7 @@ data_types:
     description: >-
       The PortSpec type describes port specifications for a network
       connection.
-    properties:  
+    properties:
       protocol:
         type: string
         description: >-
@@ -159,20 +159,24 @@ data_types:
       source:
         type: tosca.datatypes.network.PortDef
         description: >-
-          The optional source port.          
+          The optional source port.
+        required: false
       source_range:
         type: range
         description: >-
-          The optional range for the source port. 
+          The optional range for the source port.
+        required: false
         constraints:
           - in_range: [ 1, 65535 ]
-      target: 
+      target:
         type: tosca.datatypes.network.PortDef
         description: >-
-          The optional target port.  
+          The optional target port.
+        required: false
       target_range:
         type: range
         description: >-
           The optional range for the target port.
+        required: false
         constraints:
           - in_range: [ 1, 65535 ]

--- a/profiles/org.oasis-open/simple/1.3/node.yaml
+++ b/profiles/org.oasis-open/simple/1.3/node.yaml
@@ -101,7 +101,7 @@ node_types:
     requirements:
       - local_storage:
           capability: tosca.capabilities.Attachment
-          node: tosca.nodes.BlockStorage
+          node: tosca.nodes.Storage.BlockStorage
           relationship: tosca.relationships.AttachesTo
           occurrences: [0, UNBOUNDED]
     capabilities:
@@ -138,7 +138,7 @@ node_types:
         required: false
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.Compute
           relationship: tosca.relationships.HostedOn
 
@@ -153,7 +153,7 @@ node_types:
       data_endpoint: tosca.capabilities.Endpoint
       admin_endpoint: tosca.capabilities.Endpoint.Admin
       host:
-        type: tosca.capabilities.Container
+        type: tosca.capabilities.Compute
         valid_source_types: [ tosca.nodes.WebApplication ]
 
   tosca.nodes.WebApplication:
@@ -176,7 +176,7 @@ node_types:
         type: tosca.capabilities.Endpoint
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.WebServer
           relationship: tosca.relationships.HostedOn
 
@@ -196,7 +196,7 @@ node_types:
         description: the port the DBMS service will listen to for data and requests
     capabilities:
       host:
-        type: tosca.capabilities.Container
+        type: tosca.capabilities.Compute
         valid_source_types: [ tosca.nodes.Database ]
 
   tosca.nodes.Database:
@@ -228,7 +228,7 @@ node_types:
         required: false
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.DBMS
           relationship: tosca.relationships.HostedOn
     capabilities:
@@ -274,7 +274,7 @@ node_types:
       storage_endpoint:
         type: tosca.capabilities.Endpoint
 
-  tosca.nodes.BlockStorage:
+  tosca.nodes.Storage.BlockStorage:
     derived_from: tosca.nodes.Abstract.Storage
     description: >
       The TOSCA BlockStorage node currently represents a server-local

--- a/profiles/org.oasis-open/simple/1.3/node.yaml
+++ b/profiles/org.oasis-open/simple/1.3/node.yaml
@@ -355,3 +355,174 @@ node_types:
           occurrences: [0, UNBOUNDED]
           description: >-
             Connection to one or more load balanced applications
+
+  tosca.nodes.network.Network:
+    derived_from: tosca.nodes.Root
+    description: >
+      The TOSCA Network node represents a simple, logical network service.
+    properties:
+      ip_version:
+        description: >
+          The IP version of the requested network.
+        type: integer
+        required: false
+        default: 4
+        constraints:
+          - valid_values: [ 4, 6 ]
+      cidr:
+        description: >
+          The cidr block of the requested network.
+        type: string
+        required: false
+      start_ip:
+        description: >
+          The IP address to be used as the 1st one in a pool of addresses
+          derived from the cidr block full IP range.
+        type: string
+        required: false
+      end_ip:
+        description: >
+          The IP address to be used as the last one in a pool of addresses
+          derived from the cidr block full IP range.
+        type: string
+        required: false
+      gateway_ip:
+        description: >
+          The gateway IP address.
+        type: string
+        required: false
+      network_name:
+        description: >
+          An Identifier that represents an existing Network instance in the
+          underlying cloud infrastructure – OR – be used as the name of the
+          new created network.
+          . If network_name is provided along with network_id they will be
+          used to uniquely identify an existing network and not creating a
+          new one, means all other possible properties are not allowed.
+          . network_name should be more convenient for using. But in case
+          that network name uniqueness is not guaranteed then one should
+          provide a network_id as well.
+        type: string
+        required: false
+      network_id:
+        description: >
+          An Identifier that represents an existing Network instance in
+          the underlying cloud infrastructure.
+          This property is mutually exclusive with all other properties
+          except network_name.
+          . Appearance of network_id in network template instructs the
+          Tosca container to use an existing network instead of creating
+          a new one.
+          . network_name should be more convenient for using. But in case
+          that network name uniqueness is not guaranteed then one should
+          add a network_id as well.
+          . network_name and network_id can be still used together to achieve
+          both uniqueness and convenient.
+        type: string
+        required: false
+      segmentation_id:
+        description: >
+          A segmentation identifier in the underlying cloud infrastructure
+          (e.g., VLAN id, GRE tunnel id). If the segmentation_id is specified,
+          the network_type or physical_network properties should be provided
+          as well.
+        type: string
+        required: false
+      network_type:
+        description: >
+          Optionally, specifies the nature of the physical network in
+          the underlying cloud infrastructure. Examples are flat, vlan,
+          gre or vxlan. For flat and vlan types, physical_network should
+          be provided too.
+        type: string
+        required: false
+      physical_network:
+        description: >
+          Optionally, identifies the physical network on top of which the
+          network is implemented, e.g. physnet1. This property is required
+          if network_type is flat or vlan.
+        type: string
+        required: false
+      dhcp_enabled:
+        description: >
+          Indicates the TOSCA container to create a virtual network instance
+          with or without a DHCP service.
+        type: boolean
+        required: false
+        default: true
+    attributes:
+      segmentation_id:
+        description: >
+          The actual segmentation_id that is been assigned to the network
+          by the underlying cloud infrastructure.
+        type: string
+    capabilities:
+      link:
+        type: tosca.capabilities.network.Linkable
+
+  tosca.nodes.network.Port:
+    derived_from: tosca.nodes.Root
+    description: >
+      The TOSCA Port node represents a logical entity that associates
+      between Compute and Network normative types.
+      The Port node type effectively represents a single virtual NIC on
+      the Compute node instance.
+    properties:
+      ip_address:
+        description: >
+          Allow the user to set a fixed IP address.
+          Note that this address is a request to the provider which
+          they will attempt to fulfill but may not be able to dependent
+          on the network the port is associated with.
+        type: string
+        required: false
+      order:
+        description: >
+          The order of the NIC on the compute instance (e.g. eth2).
+          Note: when binding more than one port to a single compute
+          (aka multi vNICs) and ordering is desired, it is *mandatory*
+          that all ports will be set with an order value and. The order
+          values must represent a positive, arithmetic progression that
+          starts with 0 (e.g. 0, 1, 2, ..., n).
+        type: integer
+        required: true
+        default: 0
+        constraints:
+          - greater_or_equal: 0
+      is_default:
+        description: >
+          Set is_default=true to apply a default gateway route on the
+          running compute instance to the associated network gateway.
+          Only one port that is associated to single compute node can
+          set as default=true.
+        type: boolean
+        required: false
+        default: false
+      ip_range_start:
+        description: >
+          Defines the starting IP of a range to be allocated for the
+          compute instances that are associated by this Port.
+          Without setting this property the IP allocation is done from
+          the entire CIDR block of the network.
+        type: string
+        required: false
+      ip_range_end:
+        description: >
+          Defines the ending IP of a range to be allocated for the
+          compute instances that are associated by this Port.
+          Without setting this property the IP allocation is done from
+          the entire CIDR block of the network.
+        type: string
+        required: false
+    attributes:
+      ip_address:
+        description: >
+          The IP address would be assigned to the associated compute instance.
+        type: string
+    requirements:
+     - link:
+        capability: tosca.capabilities.network.Linkable
+        relationship: tosca.relationships.network.LinksTo
+     - binding:
+        capability: tosca.capabilities.network.Bindable
+        relationship: tosca.relationships.network.BindsTo

--- a/profiles/org.oasis-open/simple/1.3/node.yaml
+++ b/profiles/org.oasis-open/simple/1.3/node.yaml
@@ -10,6 +10,12 @@ description: >-
   node types as defined in the TOSCA Simple Profile for YAML v1.3
   specification.
 
+imports:
+  - data.yaml
+  - capability.yaml
+  - interface.yaml
+  - relationship.yaml
+
 node_types:
 
   tosca.nodes.Root:
@@ -60,7 +66,7 @@ node_types:
       resource without any requirements on storage or network
       resources.
     capabilities:
-      host: 
+      host:
         type: tosca.capabilities.Compute
         valid_source_types: []
 
@@ -236,11 +242,11 @@ node_types:
       resource without any requirements on compute or network
       resources.
     properties:
-      name: 
+      name:
         type: string
         description: >-
           The logical name (or ID) of the storage resource.
-      size: 
+      size:
         type: scalar-unit.size
         description: >-
           The requested initial storage size (default unit is in
@@ -304,7 +310,7 @@ node_types:
     capabilities:
       host:
         type: tosca.capabilities.Compute
-        valid_source_types: [tosca.nodes.Container.Application]        
+        valid_source_types: [tosca.nodes.Container.Application]
       scalable:
         type: tosca.capabilities.Scalable
 
@@ -338,7 +344,7 @@ node_types:
     capabilities:
       client:
         type: tosca.capabilities.Endpoint.Public
-        occurrences: [0, UNBOUNDED] 
+        occurrences: [0, UNBOUNDED]
         description: >-
           the Floating (IP) client’s on the public network can connect
           to
@@ -346,6 +352,6 @@ node_types:
       - application:
           capability: tosca.capabilities.Endpoint
           relationship: tosca.relationships.RoutesTo
-          occurrences: [0, UNBOUNDED] 
+          occurrences: [0, UNBOUNDED]
           description: >-
             Connection to one or more load balanced applications

--- a/profiles/org.oasis-open/simple/1.3/relationship.yaml
+++ b/profiles/org.oasis-open/simple/1.3/relationship.yaml
@@ -91,3 +91,17 @@ relationship_types:
       This type represents an intentional network routing between two
       Endpoints in different networks.
     valid_target_types: [ tosca.capabilities.Endpoint ]
+
+  tosca.relationships.network.LinksTo:
+    derived_from: tosca.relationships.DependsOn
+    description: >
+      This relationship type represents an association relationship between
+      Port and Network node types.
+    valid_target_types: [ tosca.capabilities.network.Linkable ]
+
+  tosca.relationships.network.BindsTo:
+    derived_from: tosca.relationships.DependsOn
+    description: >
+      This type represents a network association relationship between Port
+      and Compute node types.
+    valid_target_types: [ tosca.capabilities.network.Bindable ]

--- a/profiles/org.oasis-open/simple/1.3/relationship.yaml
+++ b/profiles/org.oasis-open/simple/1.3/relationship.yaml
@@ -10,6 +10,11 @@ description: >-
   relationship types as defined in the TOSCA Simple Profile for YAML
   v1.3 specification.
 
+imports:
+  - data.yaml
+  - capability.yaml
+  - interface.yaml
+
 relationship_types:
 
   tosca.relationships.Root:

--- a/profiles/org.oasis-open/simple/2.0/node_types.yaml
+++ b/profiles/org.oasis-open/simple/2.0/node_types.yaml
@@ -9,7 +9,7 @@ metadata:
   template_name: node_types.yaml
   template_author: Oasis Open
   template_version: 2.0
- 
+
 description: >
   TOSCA Simple Profile Version node type definitions
 
@@ -29,7 +29,7 @@ node_types:
       state:
         type: string
     capabilities:
-      feature: 
+      feature:
         type: Node
     requirements:
       - dependency:
@@ -37,9 +37,9 @@ node_types:
           node: Root
           relationship: DependsOn
           occurrences: [ 0, UNBOUNDED ]
-    interfaces: 
+    interfaces:
       Standard:
-        type: Lifecycle.Standard 
+        type: Lifecycle.Standard
 
   Abstract.Compute:
     description: >-
@@ -48,7 +48,7 @@ node_types:
       resources.
     derived_from: Root
     capabilities:
-      host: 
+      host:
         type: Compute
         valid_source_types: []
 
@@ -87,13 +87,13 @@ node_types:
         entry_schema:
           type: PortInfo
     requirements:
-      - local_storage: 
+      - local_storage:
           capability: Attachment
           node: Storage.BlockStorage
           relationship: AttachesTo
-          occurrences: [0, UNBOUNDED]  
+          occurrences: [0, UNBOUNDED]
     capabilities:
-      host: 
+      host:
         type: Compute
         valid_source_types: [SoftwareComponent]
       endpoint:
@@ -111,18 +111,18 @@ node_types:
       component that can be managed and run by a TOSCA compute node.
     derived_from: Root
     properties:
-      component_version: 
+      component_version:
         description: >
           Domain-specific software component version.
         type: version
         required: false
-      admin_credential: 
+      admin_credential:
         description: >-
           The optional credential that can be used to authenticate to the software component.
         type: Credential
         required: false
     requirements:
-      - host: 
+      - host:
           capability: Compute
           node: Compute
           relationship: HostedOn
@@ -139,7 +139,7 @@ node_types:
         description: Private layer 4 endpoints.
         type: Endpoint
       admin_endpoint: Endpoint.Admin
-      host: 
+      host:
         type: Compute
         valid_source_types: [ WebApplication ]
 
@@ -161,7 +161,7 @@ node_types:
     capabilities:
       app_endpoint: Endpoint
     requirements:
-      - host: 
+      - host:
           capability: Compute
           node: WebServer
           relationship: HostedOn
@@ -172,7 +172,7 @@ node_types:
       Management System software component or service.
     derived_from: SoftwareComponent
     properties:
-      root_password: 
+      root_password:
         type: string
         required: false
         description: >
@@ -183,8 +183,8 @@ node_types:
         description: >
           The port on which the DBMS service will listen for data and
           requests.
-    capabilities:    
-      host: 
+    capabilities:
+      host:
         type: Compute
         valid_source_types: [ Database ]
 
@@ -218,7 +218,7 @@ node_types:
           node: DBMS
           relationship: HostedOn
     capabilities:
-      database_endpoint: 
+      database_endpoint:
         type: Endpoint.Database
 
   Abstract.Storage:
@@ -228,7 +228,7 @@ node_types:
       resources.
     derived_from: Root
     properties:
-      size: 
+      size:
         type: scalar-unit.size
         constraints:
           - greater_or_equal: 0 MB
@@ -240,7 +240,7 @@ node_types:
       underlying filesystem or devices.
     derived_from: Abstract.Storage
     properties:
-      name: 
+      name:
         description: >
           The logical name of the object store (or container).
         type: string
@@ -261,7 +261,7 @@ node_types:
       of data from which raw storage volumes can be created.
     derived_from: Abstract.Storage
     properties:
-      size: 
+      size:
         description: >-
           The requested storage size. Required when an existing
           volume_id is not provided. If volume_id is provided, size is
@@ -281,7 +281,7 @@ node_types:
         type: string
         required: false
     capabilities:
-      attachment: 
+      attachment:
         type: Attachment
 
   Container.Runtime:
@@ -291,7 +291,7 @@ node_types:
       application services on a single Compute host.
     derived_from: SoftwareComponent
     capabilities:
-      host: 
+      host:
         type: Compute
       scalable:
         type: Scalable
@@ -302,7 +302,7 @@ node_types:
       that requires Container-level virtualization technology.
     derived_from: Root
     requirements:
-      - host: 
+      - host:
           capability: Compute
           node: Container.Runtime
           relationship: HostedOn
@@ -324,7 +324,7 @@ node_types:
           - valid_values: [ 4, 6 ]
       cidr:
         description: >
-          The cidr block of the requested 
+          The cidr block of the requested
         type: string
         required: false
       start_ip:
@@ -370,29 +370,29 @@ node_types:
           A segmentation identifier in the underlying cloud
           infrastructure.  E.g. VLAN ID, GRE tunnel ID, etc..
         type: string
-        required: false 
+        required: false
       network_type:
         description: >
           Specifies the nature of the physical network in the underlying
           cloud infrastructure. Examples are flat, vlan, gre or vxlan.
           For flat and vlan types, physical_network should be provided too.
         type: string
-        required: false 
+        required: false
       physical_network:
         description: >
           Identifies the physical network on top of which the network is
           implemented, e.g. physnet1. This property is required if network_type
           is flat or vlan.
         type: string
-        required: false 
-      dhcp_enabled: 
+        required: false
+      dhcp_enabled:
         description: >
           Indicates whether DHCP service should be enabled on the network or not.
         type: boolean
         default: false
     capabilities:
       link:
-        type: Linkable 
+        type: Linkable
 
   Port:
     description: >
@@ -412,7 +412,7 @@ node_types:
           The order of the NIC on the compute instance (e.g. eth2).
         type: integer
         required: true
-        default: 0 
+        default: 0
         constraints:
           - greater_or_equal: 0
       is_default:
@@ -434,9 +434,9 @@ node_types:
           Defines the ending IP of a range to be allocated for the compute
           instances that are associated with this Port.
         type: string
-        required: false  
+        required: false
     requirements:
-     - link: 
+     - link:
         description: >
           Expresses the relationship between Port and Network
           nodes. It indicates the network to which this port will connect.
@@ -463,15 +463,15 @@ node_types:
         required: false
         status: experimental
     capabilities:
-      client: 
+      client:
         type: Endpoint.Public
-        occurrences: [0, UNBOUNDED]  
+        occurrences: [0, UNBOUNDED]
         description: >
           The floating IP to which clients on the public network can connect.
     requirements:
-      - application: 
+      - application:
           capability: Endpoint
           relationship: RoutesTo
-          occurrences: [0, UNBOUNDED]  
+          occurrences: [0, UNBOUNDED]
           description: >
             Connection to one or more load balanced applications.


### PR DESCRIPTION
Added missing 
* imports
* tosca.capabilities.network.Linkable
* tosca.relationships.network.LinksTo
* tosca.relationships.network.BindsTo
* tosca.nodes.network.Network
* tosca.nodes.network.Port
* required: false

For TOSCA 1.2 and 1.3
* renamed tosca.nodes.BlockStorage to tosca.nodes.Storage.BlockStorage
* replaced capability: tosca.capabilities.Container by capability: tosca.capabilities.Compute
