### PR TITLE
Corrected some service templates in order to be TOSCA 1.3 compliant

### DIFF
--- a/examples/1.3/examples-from-spec/hello-world/hello-world.yaml
+++ b/examples/1.3/examples-from-spec/hello-world/hello-world.yaml
@@ -6,7 +6,7 @@ description: >-
 metadata:
   template_name: Hello World
   template_author: OASIS TOSCA TC
-  template_version: 1.3
+  template_version: "1.3"
   reference: TOSCA Simple Profile in YAML Version 1.3 Section 2.1
 
 topology_template:
@@ -17,15 +17,14 @@ topology_template:
         # Host container properties
         host:
          properties:
-           num_cpus: 1 
+           num_cpus: 1
            disk_size: 10 GB
            mem_size: 512 MB
         # Guest Operating System properties
         os:
           properties:
             # host Operating System image properties
-            architecture: x86_64 
-            type: linux  
+            architecture: x86_64
+            type: linux
             distribution: ubuntu
             version: '6.5'
-

--- a/examples/1.3/examples-from-spec/inputs-and-outputs/inputs-and-outputs.yaml
+++ b/examples/1.3/examples-from-spec/inputs-and-outputs/inputs-and-outputs.yaml
@@ -7,7 +7,7 @@ description: >-
 metadata:
   template_name: Hello World
   template_author: OASIS TOSCA TC
-  template_version: 1.3
+  template_version: "1.3"
   reference: TOSCA Simple Profile in YAML Version 1.3 Section 2.1.1
 
 topology_template:
@@ -32,7 +32,8 @@ topology_template:
             mem_size: 4096 MB
         # Guest Operating System properties
         os:
-          # omitted for brevity 
+          # omitted for brevity
+          {} # added to avoid an implicit null value
 
   outputs:
     server_ip:

--- a/examples/1.3/examples-from-spec/mysql/mysql.yaml
+++ b/examples/1.3/examples-from-spec/mysql/mysql.yaml
@@ -6,7 +6,7 @@ description: >-
 metadata:
   template_name: Hello World
   template_author: OASIS TOSCA TC
-  template_version: 1.3
+  template_version: "1.3"
   reference: TOSCA Simple Profile in YAML Version 1.3 Section 2.2
 
 imports:
@@ -34,13 +34,13 @@ topology_template:
         host:
           properties:
             # Compute properties
-            num_cpus: 2 
+            num_cpus: 2
             disk_size: 10 GB
             mem_size: 4 MB
         os:
           properties:
             # host Operating System image properties
-            architecture: x86_64 
-            type: linux  
-            distribution: rhel  
-            version: '6.5.0'  
+            architecture: x86_64
+            type: linux
+            distribution: rhel
+            version: '6.5.0'

--- a/examples/1.3/examples-from-spec/mysql/non-normative-types.yaml
+++ b/examples/1.3/examples-from-spec/mysql/non-normative-types.yaml
@@ -3,8 +3,8 @@ tosca_definitions_version: tosca_simple_yaml_1_3
 metadata:
   template_name: OASIS TOSCA Non-Normative Type Definitions
   template_author: OASIS TOSCA TC
-  template_version: 1.3
- 
+  template_version: "1.3"
+
 description: >-
   OASIS TOSCA non-normative profile type definitions
 
@@ -27,12 +27,12 @@ artifact_types:
     file_ext: [ qcow2 ]
 
 capability_types:
-  
+
   tosca.capabilities.Container.Docker:
     description: >-
       The Container.Docker type is a non-normative type that indicates
       capabilities of a Docker runtime environment (client).
-    short_name: Container.Docker
+#    short_name: Container.Docker # commented as this is not a valid TOSCA keyname.
     derived_from: tosca.capabilities.Compute
     properties:
       version:
@@ -40,7 +40,7 @@ capability_types:
           List of supported Docker versions.
         type: list
         required: false
-        entry_schema: 
+        entry_schema:
           type: version
       publish_all:
         description: >-
@@ -54,7 +54,7 @@ capability_types:
           List of ports mappings from source (Docker container) to
           target (host) ports to publish.
         type: list
-        entry_schema: 
+        entry_schema:
           type: PortSpec
         required: false
       expose_ports:
@@ -98,7 +98,7 @@ node_types:
       a TOSCA MySQL DBMS node.
     derived_from: tosca.nodes.Database
     requirements:
-      - host: 
+      - host:
           node: tosca.nodes.DBMS.MySQL
 
   tosca.nodes.DBMS.MySQL:
@@ -115,7 +115,7 @@ node_types:
         required: true
     capabilities:
       # Further constrain the ‘host’ capability to only allow MySQL databases
-      host: 
+      host:
         valid_source_types: [ tosca.nodes.Database.MySQL ]
 
   tosca.nodes.WebServer.Apache:
@@ -143,8 +143,8 @@ node_types:
           The logical name of the server hosting the WordPress database.
         type: string
     requirements:
-      - database_endpoint: 
-          capability: tosca.capabilities.Endpoint.Database  
+      - database_endpoint:
+          capability: tosca.capabilities.Endpoint.Database
           node: tosca.nodes.Database
           relationship: tosca.relationships.ConnectsTo
 
@@ -171,7 +171,7 @@ node_types:
       runtime environment
     derived_from: tosca.nodes.Container.Runtime
     capabilities:
-      host: 
+      host:
         type: tosca.capabilities.Container.Docker
 
   tosca.nodes.Container.Application.Docker:

--- a/profiles/cloud.puccini/kubernetes/1.0/capabilities.yaml
+++ b/profiles/cloud.puccini/kubernetes/1.0/capabilities.yaml
@@ -8,7 +8,7 @@ capability_types:
 
   Metadata:
     metadata:
-      specification.url: 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta' 
+      specification.url: 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta'
     description: >-
       ObjectMeta is metadata that all persisted resources must have, which includes all objects
       users must create.
@@ -179,7 +179,7 @@ capability_types:
 
   CustomResourceDefinition:
     metadata:
-      specification.url: 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#customresourcedefinition-v1-apiextensions-k8s-io' 
+      specification.url: 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#customresourcedefinition-v1-apiextensions-k8s-io'
       turandot.apiVersion: apiextensions.k8s.io/v1
     derived_from: Resource
     properties:
@@ -224,7 +224,7 @@ capability_types:
 
   Service:
     metadata:
-      specification.url: 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#service-v1-core' 
+      specification.url: 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#service-v1-core'
       specification.guide.url: 'https://kubernetes.io/docs/concepts/services-networking/service/'
       turandot.apiVersion: v1
       turandot.copy: metadata.labels->spec.selector
@@ -247,7 +247,7 @@ capability_types:
           the current cloud) which routes to the clusterIP.
         type: string
         constraints:
-        - valid_values: [ ExternalName, ClusterIP, NodePort, and LoadBalancer ]
+        - valid_values: [ ExternalName, ClusterIP, NodePort, LoadBalancer ]
 
       ports:
         description: >-
@@ -311,8 +311,9 @@ capability_types:
       # TODO: sessionAffinityConfig
     attributes:
       clusterIP:
-        metadata:
-          puccini.information:turandot.mapping: spec.clusterIP
+# Commented because metadata is not a valid keyname of attribute definitions in TOSCA 1.3
+#        metadata:
+#          puccini.information:turandot.mapping: spec.clusterIP
         description: >-
           clusterIP is the IP address of the service and is usually assigned randomly by the master.
           If an address is specified manually and is not in use by others, it will be allocated to
@@ -367,8 +368,9 @@ capability_types:
         required: false
     attributes:
       ingress:
-        metadata:
-          puccini.information:turandot.mapping: status.loadBalancer.ingress
+# Commented because metadata is not a valid keyname of attribute definitions in TOSCA 1.3
+#        metadata:
+#          puccini.information:turandot.mapping: status.loadBalancer.ingress
         description: >-
           Ingress is a list containing ingress points for the load-balancer. Traffic intended for
           the service should be sent to these ingress points.
@@ -406,7 +408,7 @@ capability_types:
 
   Deployment:
     metadata:
-      specification.url: 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#deployment-v1-apps' 
+      specification.url: 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#deployment-v1-apps'
       specification.guide.url: 'https://kubernetes.io/docs/concepts/workloads/controllers/deployment/'
       turandot.apiVersion: apps/v1
       turandot.move: spec.template->spec.template.spec
@@ -478,7 +480,7 @@ capability_types:
 
   NetworkAttachmentDefinition:
     metadata:
-      specification.url: 'https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/blob/master/artifacts/networks-crd.yaml' 
+      specification.url: 'https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/blob/master/artifacts/networks-crd.yaml'
       turandot.apiVersion: k8s.cni.cncf.io/v1
     derived_from: Resource
     properties:

--- a/profiles/cloud.puccini/openstack/1.0/data.yaml
+++ b/profiles/cloud.puccini/openstack/1.0/data.yaml
@@ -225,7 +225,7 @@ data_types:
           The size of the local ephemeral block device, in GB.
         type: scalar-unit.size
         constraints:
-        - greater_or_equal: 1
+        - greater_or_equal: 1 GB
       image:
         description: >-
           The ID or name of the image to create a volume from.


### PR DESCRIPTION
* Metadata `template_version` shall be a string
* `metadata` is not a valid keyname in attribute definitions
* `short_name` is not a valid keyname
* avoided implicit null value
* Fix data typing errors