### PR TITLE
Fixed invalid syntax in TOSCA 2.0 templates

### DIFF
--- a/tests/tosca_2_0/profile_versions/profile.v1/profile.yaml
+++ b/tests/tosca_2_0/profile_versions/profile.v1/profile.yaml
@@ -9,5 +9,5 @@ data_types:
         type: string
       sex:
         type: string
-        constraints:
-          - valid_values: [ male, female ]
+        validation: 
+          $valid_values: [ $value, [ male, female ] ]

--- a/tests/tosca_2_0/profile_versions/profile.v2/profile.yaml
+++ b/tests/tosca_2_0/profile_versions/profile.v2/profile.yaml
@@ -10,8 +10,8 @@ data_types:
         type: string
       sex:
         type: string
-        constraints:
-          - valid_values: [ male, female ]
+        validation: 
+          $valid_values: [ $value, [ male, female ] ]
 
   Woman:
     derived_from: Person

--- a/tests/tosca_2_0/profile_versions/service/female_participant.yaml
+++ b/tests/tosca_2_0/profile_versions/service/female_participant.yaml
@@ -21,7 +21,7 @@ node_types:
       person:
         type: p2:Woman
 
-topology_template:
+service_template:
 
   node_templates:
 


### PR DESCRIPTION
Replaced 'topology_template' with 'service_template' and property 'constraints' with 'validation'