### PR TITLE
fix: add missing tosca_definitions_version to artifact_types

### DIFF
--- a/profiles/org.oasis-open/simple/2.0/artifact_types.yaml
+++ b/profiles/org.oasis-open/simple/2.0/artifact_types.yaml
@@ -3,6 +3,8 @@
 # definitions.
 ##########################################################################
 
+tosca_definitions_version: tosca_2_0
+
 metadata:
   template_name: artifact_types.yaml
   template_author: Oasis Open


### PR DESCRIPTION
According to the recent version of TOSCA 2.0 spec ([link](https://github.com/oasis-tcs/tosca-specs/blob/working/tosca_2_0/TOSCA-v2.0.md#61-keynames)), field `tosca_definitions_version` is mandatory. This PR adds missing version to artifact type definitions in tosca 2.0 simple profile