### PR TITLE
Correct command invoking ubicity

### DIFF
--- a/tools/wrappers/wrapper_ubicity_2_5.py
+++ b/tools/wrappers/wrapper_ubicity_2_5.py
@@ -49,7 +49,7 @@ def main():
     pErrorReason = ""
 
     # Run the processor
-    processor_command = ["ubicity", "catalog",  "validate", file_path]
+    processor_command = ["ubicity", "csar",  "validate", file_path]
     result = subprocess.run(  
         processor_command,
     stdout=subprocess.PIPE,


### PR DESCRIPTION
The test wrapper for ubicity 2.5 now uses the recommended invocation command