### PR TITLE
Core profile updates

### DIFF
--- a/examples/kubernetes_clusters/main.yaml
+++ b/examples/kubernetes_clusters/main.yaml
@@ -4,7 +4,7 @@ description: >-
   Service model for onboarding Kubernetes clusters
 
 imports:
-  - profile: community.tosca.platform:0.1
+  - profile: community.tosca.abstract.platform:0.1
     namespace: plt
 
 service_template:

--- a/examples/online_boutique/main.yaml
+++ b/examples/online_boutique/main.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_2_0
 
 imports:
-  - profile: community.tosca.application:0.1
+  - profile: community.tosca.abstract.application:0.1
     namespace: app
 
 description: >-

--- a/examples/substitutions/microservice/main.yaml
+++ b/examples/substitutions/microservice/main.yaml
@@ -1,9 +1,9 @@
 tosca_definitions_version: tosca_2_0
 
 imports:
-  - profile: community.tosca.application:0.1
+  - profile: community.tosca.abstract.application:0.1
     namespace: app
-  - profile: community.tosca.kubernetes:0.1
+  - profile: community.tosca.technology.kubernetes:0.1
     namespace: k8s
 
 description: >-

--- a/profiles/community/tosca/abstract/application/profile.yaml
+++ b/profiles/community/tosca/abstract/application/profile.yaml
@@ -8,6 +8,7 @@ description: >-
   Application abstract node type
 
 imports:
+- profile: community.tosca.core:0.1
 - profile: community.tosca.abstract.base:0.1
 - profile: community.tosca.abstract.platform:0.1
   namespace: platform
@@ -101,7 +102,6 @@ node_types:
         required: true
         type: list
         entry_schema:
-          description:
           type: Process
     capabilities:
       endpoint:

--- a/profiles/community/tosca/core/functions/decode_json.py
+++ b/profiles/community/tosca/core/functions/decode_json.py
@@ -1,30 +1,5 @@
 import json
 
-def validate_json(args):
-    """
-    Validate a JSON string against a schema.
-    
-    Args:
-      args: list of arguments
-        args[0] (str): The JSON string to decode (required)
-    Returns:
-      True/False
-    Raises:
-      ValueError: If no arguments provided
-    """
-    # Make sure exactly one argument is provided
-    if len(args) != 1:
-        raise ValueError("Exactly one argument is required")
-    json_string = args[0]
-    
-    # Decode the JSON string
-    try:
-        data = json.loads(json_string)
-        return True
-    except json.JSONDecodeError: 
-        return False
-
-
 def decode_json(args):
     """
     Decode a JSON string.

--- a/profiles/community/tosca/core/functions/in_range.py
+++ b/profiles/community/tosca/core/functions/in_range.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+from typing import Any
+
+try:
+    from packaging.version import Version
+    HAS_PACKAGING = True
+except ImportError:
+    HAS_PACKAGING = False
+
+
+def _parse_timestamp(value):
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_version(value):
+    if not HAS_PACKAGING:
+        return None
+    try:
+        return Version(value)
+    except Exception:
+        return None
+
+
+def in_range(value: Any, low: Any, high: Any) -> bool:
+    """
+    Returns True if low <= value <= high.
+
+    Supported types:
+    - int
+    - float
+    - str
+    - datetime / ISO timestamp string
+    - semantic version string
+
+    Returns False if:
+    - incompatible types
+    - invalid interval
+    - parsing error
+    """
+
+    # Reject reversed interval
+    try:
+        if low > high:
+            return False
+    except Exception:
+        return False
+
+    # Numeric comparison
+    if all(isinstance(x, (int, float)) for x in (value, low, high)):
+        return low <= value <= high
+
+    # Timestamp comparison
+    v_ts = _parse_timestamp(value)
+    l_ts = _parse_timestamp(low)
+    h_ts = _parse_timestamp(high)
+
+    if all(x is not None for x in (v_ts, l_ts, h_ts)):
+        return l_ts <= v_ts <= h_ts
+
+    # Semantic version comparison
+    if HAS_PACKAGING:
+        v_ver = _parse_version(value)
+        l_ver = _parse_version(low)
+        h_ver = _parse_version(high)
+
+        if all(x is not None for x in (v_ver, l_ver, h_ver)):
+            return l_ver <= v_ver <= h_ver
+
+    # String comparison fallback
+    if all(isinstance(x, str) for x in (value, low, high)):
+        return low <= value <= high
+
+    return False
+

--- a/profiles/community/tosca/core/functions/in_range_strict.py
+++ b/profiles/community/tosca/core/functions/in_range_strict.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+from typing import Any
+
+try:
+    from packaging.version import Version
+    HAS_PACKAGING = True
+except ImportError:
+    HAS_PACKAGING = False
+
+
+def _parse_timestamp(value):
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_version(value):
+    if not HAS_PACKAGING:
+        return None
+    try:
+        return Version(value)
+    except Exception:
+        return None
+
+
+def in_range_strict(value: Any, low: Any, high: Any) -> bool:
+    """
+    Returns True if low < value < high.
+
+    Supported types:
+    - int
+    - float
+    - str
+    - datetime / ISO timestamp string
+    - semantic version string
+
+    Returns False if:
+    - incompatible types
+    - invalid interval
+    - parsing error
+    """
+
+    # Reject identical bounds or reversed interval
+    try:
+        if low >= high:
+            return False
+    except Exception:
+        return False
+
+    # Numeric comparison
+    if all(isinstance(x, (int, float)) for x in (value, low, high)):
+        return low < value < high
+
+    # Timestamp comparison
+    v_ts = _parse_timestamp(value)
+    l_ts = _parse_timestamp(low)
+    h_ts = _parse_timestamp(high)
+
+    if all(x is not None for x in (v_ts, l_ts, h_ts)):
+        return l_ts < v_ts < h_ts
+
+    # Semantic version comparison
+    if HAS_PACKAGING:
+        v_ver = _parse_version(value)
+        l_ver = _parse_version(low)
+        h_ver = _parse_version(high)
+
+        if all(x is not None for x in (v_ver, l_ver, h_ver)):
+            return l_ver < v_ver < h_ver
+
+    # String comparison fallback
+    if all(isinstance(x, str) for x in (value, low, high)):
+        return low < value < high
+
+    return False
+

--- a/profiles/community/tosca/core/functions/to_string.py
+++ b/profiles/community/tosca/core/functions/to_string.py
@@ -4,9 +4,3 @@ def to_string(args):
     else:
         return None
 
-def to_uppercase(args):
-    if args and args[0]:
-        return args[0].upper()
-    else:
-        return None
-

--- a/profiles/community/tosca/core/functions/to_uppercase.py
+++ b/profiles/community/tosca/core/functions/to_uppercase.py
@@ -1,0 +1,6 @@
+def to_uppercase(args):
+    if args and args[0]:
+        return args[0].upper()
+    else:
+        return None
+

--- a/profiles/community/tosca/core/functions/validate_json.py
+++ b/profiles/community/tosca/core/functions/validate_json.py
@@ -1,0 +1,26 @@
+import json
+
+def validate_json(args):
+    """
+    Validate a JSON string against a schema.
+    
+    Args:
+      args: list of arguments
+        args[0] (str): The JSON string to decode (required)
+    Returns:
+      True/False
+    Raises:
+      ValueError: If no arguments provided
+    """
+    # Make sure exactly one argument is provided
+    if len(args) != 1:
+        raise ValueError("Exactly one argument is required")
+    json_string = args[0]
+    
+    # Decode the JSON string
+    try:
+        data = json.loads(json_string)
+        return True
+    except json.JSONDecodeError: 
+        return False
+

--- a/profiles/community/tosca/core/profile.yaml
+++ b/profiles/community/tosca/core/profile.yaml
@@ -29,7 +29,7 @@ data_types:
     description: >-
       The Port type defines integer that contain valid ports
     derived_from: integer
-    validation: {$in_range: [$value, [0, 0xFFFF]]}
+    validation: {$in_range: [$value, 0, 65535]}
   IPv4Socket:
     description: >-
       This complex type represents an IPv4 socket (address+port)
@@ -115,8 +115,7 @@ functions:
             description: >-
               The integer to convert to string
         result: string
-        implementation: functions.string:to_string
-        # The implementation string is currently not standard TOSCA
+        implementation: functions/to_string.py
   to_uppercase:
     description: >-
       Convert a string to upper case
@@ -126,8 +125,7 @@ functions:
             description: >-
               The string to convert to upper case.
         result: string
-        implementation: functions.string:to_uppercase
-        # The implementation string is currently not standard TOSCA
+        implementation: functions/to_uppercase.py
   validate_json:
     description: >-
       Check if a string argument contains valid JSON.
@@ -137,13 +135,53 @@ functions:
             description: >-
               The json string to validate.
         result: boolean
-        implementation: functions.json_utils:validate_json
-        # The implementation string is currently not standard TOSCA
+        implementation: functions/validate_json.py
   decode_json:
     signatures:
       - arguments:
           - type: string
             description: >-
               The json string to decode
-        implementation: functions.json_utils:decode_json
-        # The implementation string is currently not standard TOSCA
+        implementation: functions/decode_json.py
+  in_range:
+    description: >
+        This function provide true if first argument (value) is within
+        the range delimited by the second (min) and the third (max)
+        min <= value <= max
+        Arguments shall be integers, floats, strings or versions.
+        In any other case, including errors, it provides false.
+    signatures:
+      - arguments: [integer, integer, integer]
+        result: boolean
+        implementation: functions/in_range.py
+      - arguments: [float, float, float]
+        result: boolean
+        implementation: functions/in_range.py
+      - arguments: [string, string, string]
+        result: boolean
+        implementation: functions/in_range.py
+      - arguments: [version, version, version]
+        result: boolean
+        implementation: functions/in_range.py
+  in_range_strict:
+    description: >
+        This function provide true if first argument (value) is within
+        the range delimited by the second (min) and the third (max)
+        min < value < max
+        Strict comparison is used (i.e. value cannot be equal to
+        interval boundaries)
+        Arguments shall be integers, floats, strings or versions.
+        In any other case, including errors, it provides false.
+    signatures:
+      - arguments: [integer, integer, integer]
+        result: boolean
+        implementation: functions/in_range_strict.py
+      - arguments: [float, float, float]
+        result: boolean
+        implementation: functions/in_range_strict.py
+      - arguments: [string, string, string]
+        result: boolean
+        implementation: functions/in_range_strict.py
+      - arguments: [version, version, version]
+        result: boolean
+        implementation: functions/in_range_strict.py


### PR DESCRIPTION
Hi Chris,

I have submitted this PR that includes the following changes:

- the following examples have been updated to reflect the current profile naming:
```
/examples/kubernetes_clusters/main.yaml
/examples/online_boutique/main.yaml
/examples/substitutions/microservice/main.yaml

```
- the application profile in `/profiles/community/tosca/abstract/application/profile.yaml` now imports also the `core` profile (needed to support some types, e.g. `Port`)
- I have also updated the core profile in `/profiles/community/tosca/core/profile.yaml` as follows:
  - introduced custom function definitions for `$in_range` and `$in_range_strict` functions
  - minor change in `Port` data type definition to reflect the `$in_range` custom definition above
  - the `implementation` of custom function already defined have been slightly updated to comply with TOSCA standard implementation definition (see my e-mail of last week)
  - As a consequence of the above, I have also split the previous functions `json_utils.py` and `string.py`, in order to separate functions into distinct files
  - I have added specific implementations for new `$in_range` and `$in_range_strict` functions (hope they are correct, I'm not very experienced with Python) 

So far I do not have added bash scripts as alternative implementations into this profile (as proposed in another mail). If needed I can do this by submitting another PR.

If there is something that does not convince you (e.g. in the split of function implementation), reject the PR and I will correct it (or correct it on your own, as you prefer).

Thank you
Roberto
