### PR TITLE
Restore TOSCA.meta + directory logic in wrapper_ubicity_2_5.py

### DIFF
--- a/tools/wrappers/wrapper_ubicity_2_5.py
+++ b/tools/wrappers/wrapper_ubicity_2_5.py
@@ -43,21 +43,33 @@ def main():
     tosca_meta_file_path = None
     file_dir = os.path.dirname(file_path)
 
+    # Ubicity requires TOSCA.meta file for yaml files
+    if file_ext == '.yaml':
+        file_name = os.path.basename(file_path)
+        tosca_meta_file_path = os.path.join(file_dir, "TOSCA.meta")
+        with open(tosca_meta_file_path, 'w') as file:
+            file.write("CSAR-Version: 2.0\n")
+            file.write("Created-By: Ubicity Corp.\n")
+            file.write(f"Entry-Definitions: {file_name}\n")
+
     # Initialize variables
     pSuccess = False
     pError = False
     pErrorReason = ""
 
     # Run the processor
-    processor_command = ["ubicity", "csar",  "validate", file_path]
-    result = subprocess.run(  
+    processor_command = ["ubicity", "csar",  "validate", file_dir]
+    result = subprocess.run(
         processor_command,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
     text=True
     )
 
-    
+    # Clean up TOSCA.meta if it was created
+    if tosca_meta_file_path:
+        os.remove(tosca_meta_file_path)
+
     # Condition if the TOSCA file was processed successfully
     if ((result.returncode == 0)):
         pSuccess = True


### PR DESCRIPTION
The 2_5 wrapper had dropped the TOSCA.meta-creation step and was running 'ubicity csar validate' on the lone YAML file. Ubicity then copies just that one file into a fresh repo, so any relative import has nothing to resolve against and the test fails on perfectly valid TOSCA. Restore the dance the 2_4 wrapper used (write a TOSCA.meta with Entry-Definitions: <basename> next to the file, run the processor against the directory, clean up the TOSCA.meta), but keep the intentional shift from 'ubicity catalog validate' to 'ubicity csar validate'.