### PR TITLE
Reviewed $in_range() and $in_range_strict() custom functions in core profile

### DIFF
--- a/profiles/community/tosca/core/functions/in_range.py
+++ b/profiles/community/tosca/core/functions/in_range.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any
+from numbers import Real
 
 try:
     from packaging.version import Version
@@ -8,58 +8,164 @@ except ImportError:
     HAS_PACKAGING = False
 
 
-def _parse_timestamp(value):
+def _is_numeric(value):
+    """Return True for numeric values, explicitly excluding booleans."""
+    return isinstance(value, Real) and not isinstance(value, bool)
+
+
+def _parse_datetime(value):
+    """Parse datetime objects or ISO 8601 datetime strings."""
     if isinstance(value, datetime):
         return value
+
     if isinstance(value, str):
         try:
             return datetime.fromisoformat(value)
         except ValueError:
             return None
+
     return None
 
 
+def _same_datetime_flavour(*values):
+    """
+    Return True only if all datetime values are consistently timezone-aware
+    or consistently timezone-naive.
+    """
+    awareness = {
+        value.tzinfo is not None and value.tzinfo.utcoffset(value) is not None
+        for value in values
+    }
+
+    return len(awareness) == 1
+
+
 def _parse_version(value):
+    """Parse a PEP 440 compliant version string."""
     if not HAS_PACKAGING:
         return None
+
+    if not isinstance(value, str):
+        return None
+
     try:
         return Version(value)
     except Exception:
         return None
 
 
-def in_range(args) -> bool:
-    """Returns True if low <= value <= high.
-
-    Supported types: int, float, str, datetime / ISO timestamp string,
-    semantic version string.
+def _normalize_values(value, low, high):
     """
-    value, low, high = args[0], args[1], args[2]
+    Normalize value, low and high according to the following type hierarchy:
+
+    1. numeric
+    2. datetime
+    3. version
+    4. string
+
+    Return:
+        tuple[str, object, object, object]
+
+    Return None if the three values cannot be normalized to the same
+    logical type.
+    """
+
+    # 1. numeric
+    if all(_is_numeric(item) for item in (value, low, high)):
+        return "numeric", value, low, high
+
+    # 2. datetime
+    parsed_value = _parse_datetime(value)
+    parsed_low = _parse_datetime(low)
+    parsed_high = _parse_datetime(high)
+
+    if all(item is not None for item in (parsed_value, parsed_low, parsed_high)):
+        if not _same_datetime_flavour(parsed_value, parsed_low, parsed_high):
+            return None
+
+        return "datetime", parsed_value, parsed_low, parsed_high
+
+    # 3. version
+    parsed_value = _parse_version(value)
+    parsed_low = _parse_version(low)
+    parsed_high = _parse_version(high)
+
+    if all(item is not None for item in (parsed_value, parsed_low, parsed_high)):
+        return "version", parsed_value, parsed_low, parsed_high
+
+    # 4. string
+    if all(isinstance(item, str) for item in (value, low, high)):
+        return "string", value, low, high
+
+    return None
+
+
+def _extract_value_and_range(args):
+    """
+    Validate and extract the input structure.
+
+    Expected input:
+        [value, [min, max]]
+
+    Return:
+        tuple[object, object, object]
+
+    Return None if the input structure is invalid.
+    """
+    if not isinstance(args, (list, tuple)):
+        return None
+
+    if len(args) != 2:
+        return None
+
+    value = args[0]
+    range_value = args[1]
+
+    if not isinstance(range_value, (list, tuple)):
+        return None
+
+    if len(range_value) != 2:
+        return None
+
+    low, high = range_value
+
+    return value, low, high
+
+
+
+def in_range(args) -> bool:
+    """
+    Return True if value is included in the closed range [min, max].
+
+    Expected input:
+        [value, [min, max]]
+
+    Supported logical types, evaluated in this order:
+        1. numeric
+        2. datetime
+        3. version
+        4. string
+
+    Semantics:
+        min <= value <= max
+    """
+    extracted = _extract_value_and_range(args)
+
+    if extracted is None:
+        return False
+
+    value, low, high = extracted
+    normalized = _normalize_values(value, low, high)
+
+    if normalized is None:
+        return False
+
+    _, value, low, high = normalized
 
     try:
         if low > high:
             return False
+
+        return low <= value <= high
     except Exception:
         return False
-
-    if all(isinstance(x, (int, float)) for x in (value, low, high)):
-        return low <= value <= high
-
-    v_ts = _parse_timestamp(value)
-    l_ts = _parse_timestamp(low)
-    h_ts = _parse_timestamp(high)
-    if all(x is not None for x in (v_ts, l_ts, h_ts)):
-        return l_ts <= v_ts <= h_ts
-
-    if HAS_PACKAGING:
-        v_ver = _parse_version(value)
-        l_ver = _parse_version(low)
-        h_ver = _parse_version(high)
-        if all(x is not None for x in (v_ver, l_ver, h_ver)):
-            return l_ver <= v_ver <= h_ver
-
-    if all(isinstance(x, str) for x in (value, low, high)):
-        return low <= value <= high
-
-    return False
-

--- a/profiles/community/tosca/core/functions/in_range_strict.py
+++ b/profiles/community/tosca/core/functions/in_range_strict.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any
+from numbers import Real
 
 try:
     from packaging.version import Version
@@ -8,58 +8,164 @@ except ImportError:
     HAS_PACKAGING = False
 
 
-def _parse_timestamp(value):
+def _is_numeric(value):
+    """Return True for numeric values, explicitly excluding booleans."""
+    return isinstance(value, Real) and not isinstance(value, bool)
+
+
+def _parse_datetime(value):
+    """Parse datetime objects or ISO 8601 datetime strings."""
     if isinstance(value, datetime):
         return value
+
     if isinstance(value, str):
         try:
             return datetime.fromisoformat(value)
         except ValueError:
             return None
+
     return None
 
 
+def _same_datetime_flavour(*values):
+    """
+    Return True only if all datetime values are consistently timezone-aware
+    or consistently timezone-naive.
+    """
+    awareness = {
+        value.tzinfo is not None and value.tzinfo.utcoffset(value) is not None
+        for value in values
+    }
+
+    return len(awareness) == 1
+
+
 def _parse_version(value):
+    """Parse a PEP 440 compliant version string."""
     if not HAS_PACKAGING:
         return None
+
+    if not isinstance(value, str):
+        return None
+
     try:
         return Version(value)
     except Exception:
         return None
 
 
-def in_range_strict(args) -> bool:
-    """Returns True if low < value < high.
-
-    Supported types: int, float, str, datetime / ISO timestamp string,
-    semantic version string.
+def _normalize_values(value, low, high):
     """
-    value, low, high = args[0], args[1], args[2]
+    Normalize value, low and high according to the following type hierarchy:
+
+    1. numeric
+    2. datetime
+    3. version
+    4. string
+
+    Return:
+        tuple[str, object, object, object]
+
+    Return None if the three values cannot be normalized to the same
+    logical type.
+    """
+
+    # 1. numeric
+    if all(_is_numeric(item) for item in (value, low, high)):
+        return "numeric", value, low, high
+
+    # 2. datetime
+    parsed_value = _parse_datetime(value)
+    parsed_low = _parse_datetime(low)
+    parsed_high = _parse_datetime(high)
+
+    if all(item is not None for item in (parsed_value, parsed_low, parsed_high)):
+        if not _same_datetime_flavour(parsed_value, parsed_low, parsed_high):
+            return None
+
+        return "datetime", parsed_value, parsed_low, parsed_high
+
+    # 3. version
+    parsed_value = _parse_version(value)
+    parsed_low = _parse_version(low)
+    parsed_high = _parse_version(high)
+
+    if all(item is not None for item in (parsed_value, parsed_low, parsed_high)):
+        return "version", parsed_value, parsed_low, parsed_high
+
+    # 4. string
+    if all(isinstance(item, str) for item in (value, low, high)):
+        return "string", value, low, high
+
+    return None
+
+
+def _extract_value_and_range(args):
+    """
+    Validate and extract the input structure.
+
+    Expected input:
+        [value, [min, max]]
+
+    Return:
+        tuple[object, object, object]
+
+    Return None if the input structure is invalid.
+    """
+    if not isinstance(args, (list, tuple)):
+        return None
+
+    if len(args) != 2:
+        return None
+
+    value = args[0]
+    range_value = args[1]
+
+    if not isinstance(range_value, (list, tuple)):
+        return None
+
+    if len(range_value) != 2:
+        return None
+
+    low, high = range_value
+
+    return value, low, high
+
+
+
+def in_range_strict(args) -> bool:
+    """
+    Return True if value is included in the open range (min, max).
+
+    Expected input:
+        [value, [min, max]]
+
+    Supported logical types, evaluated in this order:
+        1. numeric
+        2. datetime
+        3. version
+        4. string
+
+    Semantics:
+        min < value < max
+    """
+    extracted = _extract_value_and_range(args)
+
+    if extracted is None:
+        return False
+
+    value, low, high = extracted
+    normalized = _normalize_values(value, low, high)
+
+    if normalized is None:
+        return False
+
+    _, value, low, high = normalized
 
     try:
         if low >= high:
             return False
+
+        return low < value < high
     except Exception:
         return False
-
-    if all(isinstance(x, (int, float)) for x in (value, low, high)):
-        return low < value < high
-
-    v_ts = _parse_timestamp(value)
-    l_ts = _parse_timestamp(low)
-    h_ts = _parse_timestamp(high)
-    if all(x is not None for x in (v_ts, l_ts, h_ts)):
-        return l_ts < v_ts < h_ts
-
-    if HAS_PACKAGING:
-        v_ver = _parse_version(value)
-        l_ver = _parse_version(low)
-        h_ver = _parse_version(high)
-        if all(x is not None for x in (v_ver, l_ver, h_ver)):
-            return l_ver < v_ver < h_ver
-
-    if all(isinstance(x, str) for x in (value, low, high)):
-        return low < value < high
-
-    return False
-

--- a/profiles/community/tosca/core/profile.yaml
+++ b/profiles/community/tosca/core/profile.yaml
@@ -1,7 +1,5 @@
 tosca_definitions_version: tosca_2_0
-
 profile: community.tosca.core:0.1
-
 description: >-
   TOSCA Community Core Profile type definitions. These definitions are
   intended to be shared between profiles of all levels of abstraction.
@@ -29,7 +27,7 @@ data_types:
     description: >-
       The Port type defines integer that contain valid ports
     derived_from: integer
-    validation: {$in_range: [$value, 0, 65535]}
+    validation: {$in_range: [$value, [0, 65535]]}
   IPv4Socket:
     description: >-
       This complex type represents an IPv4 socket (address+port)
@@ -118,11 +116,11 @@ capability_types:
       Base capability type for capabilities that can be targeted by an
       AssociatesWith relationship.
     valid_relationship_types: [AssociatesWith]
-    
+
 functions:
   to_string:
     description: >-
-      Convert an integer to string 
+      Convert an integer to string
     signatures:
       - arguments:
           - type: integer
@@ -171,31 +169,54 @@ functions:
             file: functions/decode_json.py
   in_range:
     description: >
-        This function provide true if first argument (value) is within
-        the range delimited by the second (min) and the third (max)
+        This function provides true if the first argument (value) is within
+        the range specified by the second argument.
+        The range argument shall be a two-item list [min, max].
         min <= value <= max
-        Arguments shall be integers, floats, strings or versions.
+        Arguments shall be integers, floats, strings, timestamps
+        or versions.
         In any other case, including errors, it provides false.
     signatures:
-      - arguments: [integer, integer, integer]
+      - arguments:
+          - type: integer
+          - type: list
+            entry_schema: integer
         result: boolean
         implementation:
           primary:
             type: Python
             file: functions/in_range.py
-      - arguments: [float, float, float]
+      - arguments:
+          - type: float
+          - type: list
+            entry_schema: float
         result: boolean
         implementation:
           primary:
             type: Python
             file: functions/in_range.py
-      - arguments: [string, string, string]
+      - arguments:
+          - type: string
+          - type: list
+            entry_schema: string
         result: boolean
         implementation:
           primary:
             type: Python
             file: functions/in_range.py
-      - arguments: [version, version, version]
+      - arguments:
+          - type: timestamp
+          - type: list
+            entry_schema: timestamp
+        result: boolean
+        implementation:
+          primary:
+            type: Python
+            file: functions/in_range.py
+      - arguments:
+          - type: version
+          - type: list
+            entry_schema: version
         result: boolean
         implementation:
           primary:
@@ -203,33 +224,56 @@ functions:
             file: functions/in_range.py
   in_range_strict:
     description: >
-        This function provide true if first argument (value) is within
-        the range delimited by the second (min) and the third (max)
+        This function provides true if the first argument (value) is within
+        the range specified by the second argument.
+        The range argument shall be a two-item list [min, max].
         min < value < max
         Strict comparison is used (i.e. value cannot be equal to
         interval boundaries)
-        Arguments shall be integers, floats, strings or versions.
+        Arguments shall be integers, floats, strings, timestamps
+        or versions.
         In any other case, including errors, it provides false.
     signatures:
-      - arguments: [integer, integer, integer]
+      - arguments:
+          - type: integer
+          - type: list
+            entry_schema: integer
         result: boolean
         implementation:
           primary:
             type: Python
             file: functions/in_range_strict.py
-      - arguments: [float, float, float]
+      - arguments:
+          - type: float
+          - type: list
+            entry_schema: float
         result: boolean
         implementation:
           primary:
             type: Python
             file: functions/in_range_strict.py
-      - arguments: [string, string, string]
+      - arguments:
+          - type: string
+          - type: list
+            entry_schema: string
         result: boolean
         implementation:
           primary:
             type: Python
             file: functions/in_range_strict.py
-      - arguments: [version, version, version]
+      - arguments:
+          - type: timestamp
+          - type: list
+            entry_schema: timestamp
+        result: boolean
+        implementation:
+          primary:
+            type: Python
+            file: functions/in_range_strict.py
+      - arguments:
+          - type: version
+          - type: list
+            entry_schema: version
         result: boolean
         implementation:
           primary:


### PR DESCRIPTION
Hi Chris,

here follows the PR we discussed a couple of weeks ago. It updates the `$in_range` and `$in_range_strict` custom functions to accept a TOSCA v.1.3 style range value instead of separate minimum and maximum arguments.

Changes included:

- Updated function signatures:

  ```yaml
  from:

  $in_range: [ value, min, max ]
  $in_range_strict: [ value, min, max ]

  to:

  $in_range: [ value, [ min, max ] ]
  $in_range_strict: [ value, [ min, max ] ]

- Updated the corresponding function definitions in `profile.yaml` (all existing signatures have been updated according to the new syntax and a new signatures to accept timestamps has also been added)
- Updated the Python implementations of both functions (besides the signature changes, the functions have been also improved in terms of robustness)
- Updated the Port data type validation to use the new syntax.

Function semantics remain unchanged:

- $in_range: inclusive comparison (min <= value <= max)
- $in_range_strict: exclusive comparison (min < value < max)

As in the previous version, invalid ranges, unsupported types, or comparison errors return false.

Thank you
Roberto