### PR TITLE
Add CSAR release workflow and cosign verification helpers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: TOSCA Community profiles release
+
+# Cut a release by pushing a semver tag (e.g. v0.1) or running this workflow
+# manually. It builds a CSAR for each community.tosca.* profile, signs them with
+# Sigstore keyless signing, and opens a DRAFT GitHub Release for review before
+# publishing.
+#
+# This is a public repository, so the release-asset download URLs work without
+# authentication -- no assets-API URL table is needed (unlike private repos).
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+-rc.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+
+permissions:
+  contents: write
+  id-token: write  # Required for Sigstore keyless signing (OIDC).
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Build CSARs
+        run: bash ./tools/scripts/build_csars.sh
+
+      - name: Sign and checksum
+        shell: bash
+        run: |
+          cd /tmp/csars
+          # Checksum manifest over all CSARs.
+          sha256sum *.csar > checksums.txt
+          # Sigstore keyless signing; --bundle writes the verification bundle.
+          cosign sign-blob --yes checksums.txt --bundle checksums.txt.bundle
+          for file in *.csar; do
+            cosign sign-blob --yes "$file" --bundle "$file".bundle
+          done
+
+      - name: Create draft GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          draft: true
+          # /tmp/csars is where build_csars.sh writes.
+          files: |
+            /tmp/csars/*.csar
+            /tmp/csars/checksums.txt
+            /tmp/csars/*.bundle
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/scripts/build_csars.sh
+++ b/tools/scripts/build_csars.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Build a CSAR for each community-authored profile under
+# profiles/community/tosca/. Profiles are discovered by their TOSCA.meta files
+# (the authoritative CSAR entry-point marker); each CSAR filename is derived from
+# the profile's advertised name+version -- the `profile:` keyword in the file
+# named by that TOSCA.meta's Entry-Definitions -- so no list is kept in sync.
+#
+# CSARs are written to ${CSARS_DIR} (default /tmp/csars).
+
+set -eo pipefail
+
+HERE=$(dirname "$(readlink --canonicalize "$BASH_SOURCE")")
+ROOT=$(readlink --canonicalize "${HERE}/../..")   # tools/scripts -> repo root
+CSARS_DIR="${CSARS_DIR:-/tmp/csars}"
+PROFILES_ROOT="${ROOT}/profiles/community/tosca"
+
+mkdir -p "${CSARS_DIR}"
+
+# Package one profile directory (identified by its TOSCA.meta) as a CSAR,
+# naming it from the profile keyword in the declared entry file.
+build_csar() {
+    local dir="$1"
+    local entry name_version csar
+    entry=$(awk -F': *' '/^Entry-Definitions:/{print $2; exit}' "${dir}/TOSCA.meta")
+    entry="${entry:-profile.yaml}"
+    name_version=$(awk '/^profile:/{print $2; exit}' "${dir}/${entry}")
+    if [ -z "${name_version}" ]; then
+        echo "WARNING: no 'profile:' keyword in ${dir}/${entry}; skipping" >&2
+        return
+    fi
+    csar="${name_version/:/.}.csar"   # community.tosca.core:0.1 -> community.tosca.core.0.1.csar
+    echo "Creating ${name_version}  ->  ${csar}"
+    ( cd "${dir}" && zip -r "${CSARS_DIR}/${csar}" . > /dev/null )
+}
+
+# Discover profiles by their TOSCA.meta entry-point markers.
+while IFS= read -r meta; do
+    build_csar "$(dirname "${meta}")"
+done < <(find "${PROFILES_ROOT}" -name TOSCA.meta | sort)
+
+echo
+echo "CSARs written to ${CSARS_DIR}:"
+ls -1 "${CSARS_DIR}"/*.csar

--- a/tools/scripts/verify_all.sh
+++ b/tools/scripts/verify_all.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# verify_all.sh - Verifies all CSAR files in the current directory.
+
+# Absolute path of this script's directory, so verify_release.sh is found
+# regardless of where this is invoked from.
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+VERIFY_SCRIPT="$SCRIPT_DIR/verify_release.sh"
+
+if [ ! -f "$VERIFY_SCRIPT" ]; then
+    echo "Error: Could not find $VERIFY_SCRIPT"
+    exit 1
+fi
+chmod +x "$VERIFY_SCRIPT"
+
+# CSAR files in the CURRENT working directory (the download folder).
+shopt -s nullglob
+artifacts=(*.csar)
+
+if [ ${#artifacts[@]} -eq 0 ]; then
+    echo "No .csar files found in $(pwd). Please run this from your download folder."
+    exit 1
+fi
+
+echo "Starting batch verification for all CSAR artifacts..."
+echo "----------------------------------------------------"
+
+for artifact in "${artifacts[@]}"; do
+    echo "Verifying: $artifact"
+    "$VERIFY_SCRIPT" "$artifact"
+    if [ $? -ne 0 ]; then
+        echo "❌ Batch verification failed at $artifact"
+        exit 1
+    fi
+    echo "----------------------------------------------------"
+done
+
+echo "✅ All artifacts verified successfully!"

--- a/tools/scripts/verify_release.sh
+++ b/tools/scripts/verify_release.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Usage: ./verify_release.sh <artifact_name>.csar
+#
+# Verifies one downloaded CSAR: its SHA-256 against the signed checksums.txt, and
+# its Sigstore keyless signature against the identity of the repo that produced
+# it. Real releases come from oasis-open; override GITHUB_ORG when verifying a
+# release cut from a fork (e.g. GITHUB_ORG=<user> ./verify_release.sh ...).
+
+ARTIFACT=$1
+GITHUB_ORG="${GITHUB_ORG:-oasis-open}"
+REPO_NAME="${REPO_NAME:-tosca-community-contributions}"
+BUNDLE="$ARTIFACT.bundle"
+CHECKSUM_FILE="checksums.txt"
+
+if [ -z "$ARTIFACT" ]; then
+    echo "Usage: $0 <file.csar>"
+    echo "Example: $0 community.tosca.core.0.1.csar"
+    exit 1
+fi
+
+echo "--- 1. Checking SHA-256 Checksum ---"
+if [ -f "$CHECKSUM_FILE" ]; then
+    grep "$ARTIFACT" "$CHECKSUM_FILE" | sha256sum --check
+else
+    echo "Error: $CHECKSUM_FILE not found. Integrity check failed."
+    exit 1
+fi
+
+echo -e "\n--- 2. Verifying Sigstore Keyless Signature ---"
+# Strictly validate that the signature came from the $GITHUB_ORG/$REPO_NAME repo.
+cosign verify-blob "$ARTIFACT" \
+  --bundle "$BUNDLE" \
+  --certificate-identity-regexp "https://github.com/$GITHUB_ORG/$REPO_NAME/.github/workflows/.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+if [ $? -eq 0 ]; then
+    echo -e "\n✅ Verification Successful: The artifact is authentic and untampered."
+else
+    echo -e "\n❌ Verification Failed!"
+    exit 1
+fi


### PR DESCRIPTION
Adds a GitHub Actions release workflow that packages the community profiles as signed CSAR artifacts, implementing the release-process decision from the 2026-07-01 meeting (a workflow packaging CSAR artifacts, a `0.1` release, flat directory structure).

## What it adds

- **`.github/workflows/release.yml`** — on a semver tag (e.g. `v0.1`) or manual dispatch, builds a CSAR for each `community.tosca.*` profile, signs them with Sigstore keyless signing (cosign), and opens a **draft** GitHub Release for review before publishing.
- **`tools/scripts/build_csars.sh`** — discovers profiles by their `TOSCA.meta` entry-point markers and names each CSAR from the profile's advertised name+version (the `profile:` keyword), so no profile list is maintained by hand.
- **`tools/scripts/verify_release.sh` / `verify_all.sh`** — cosign helpers a consumer can run to verify a downloaded CSAR's checksum and Sigstore signature against this repository's identity.

## Notes

- Draft-first: the workflow opens a *draft* release; a maintainer reviews and publishes.
- Download URLs on a public repo need no authentication, so no assets-API URL table is included.
- Currently packages the nine `community.tosca.*` profiles (core, the five `abstract.*`, and the three `technology.*`).

## Testing

Validated end-to-end in a fork: the workflow built and signed all nine CSARs, opened a draft release, and `verify_all.sh` verified every artifact against the fork's signing identity.
